### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/wangguanran/ProjectManager/security/code-scanning/1](https://github.com/wangguanran/ProjectManager/security/code-scanning/1)

To fix the problem, we should explicitly define a `permissions:` block that grants only the minimal set of privileges required for the workflow to execute. For a typical linting workflow (like this one), this means setting `contents: read` at either the workflow root or at the job level, unless the workflow requires the ability to write to PRs or other parts of the repository (which it does not, in the code shown). The best practice is to add this at the workflow root (above or below `on:` but outside of `jobs:`) so it applies to all jobs by default. To implement, insert:

```yaml
permissions:
  contents: read
```

after the workflow `name:` and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
