### PR TITLE
Refine project metadata and builder utilities

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+"""ProjectManager package bootstrap."""
+
+__all__ = []

--- a/src/hooks/executor.py
+++ b/src/hooks/executor.py
@@ -1,17 +1,18 @@
-"""
-Hook execution engine for extensible project building operations.
-"""
+"""Execution utilities for running registered hooks."""
 
+from __future__ import annotations
+
+import inspect
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
-from src.hooks.registry import HookType, get_hooks
+from src.hooks.registry import HookInfo, HookSignatureSummary, HookTypeLike, get_hooks
 
 log = logging.getLogger(__name__)
 
 
 def execute_hooks(
-    hook_type: Union[str, "HookType"],
+    hook_type: HookTypeLike,
     context: Dict[str, Any],
     platform: Optional[str] = None,
     stop_on_error: bool = False,
@@ -28,7 +29,7 @@ def execute_hooks(
     Returns:
         True if all hooks executed successfully, False otherwise
     """
-    hooks = get_hooks(hook_type, platform)
+    hooks: list[HookInfo] = get_hooks(hook_type, platform)
 
     if not hooks:
         log.debug("No hooks found for type '%s'", hook_type)
@@ -38,14 +39,12 @@ def execute_hooks(
 
     for hook_info in hooks:
         hook_name = hook_info["name"]
-        hook_func = hook_info["func"]
         hook_priority = hook_info["priority"]
 
         try:
             log.debug("Executing hook '%s' with priority %d", hook_name, hook_priority.value)
 
-            # Execute the hook function
-            hook_result = hook_func(context)
+            hook_result = _invoke_hook(hook_info, context)
 
             # Check if hook returned False (failure)
             if hook_result is False:
@@ -54,9 +53,8 @@ def execute_hooks(
 
             log.debug("Hook '%s' executed successfully", hook_name)
 
-        except (RuntimeError, ValueError, TypeError, OSError, AttributeError) as e:
-            error_msg = f"Error executing hook '{hook_name}': {str(e)}"
-            log.error(error_msg)
+        except (RuntimeError, ValueError, TypeError, OSError, AttributeError) as exc:
+            log.error("Error executing hook '%s': %s", hook_name, exc)
 
             if stop_on_error:
                 log.error("Stopping hook execution due to error in '%s'", hook_name)
@@ -67,7 +65,7 @@ def execute_hooks(
 
 
 def execute_single_hook(
-    hook_type: Union[str, "HookType"], hook_name: str, context: Dict[str, Any], platform: Optional[str] = None
+    hook_type: HookTypeLike, hook_name: str, context: Dict[str, Any], platform: Optional[str] = None
 ) -> Dict[str, Any]:
     """
     Execute a specific hook by name.
@@ -86,10 +84,10 @@ def execute_single_hook(
     for hook_info in hooks:
         if hook_info["name"] == hook_name:
             try:
-                hook_result = hook_info["func"](context)
+                hook_result = _invoke_hook(hook_info, context)
                 return {"success": True, "hook_name": hook_name, "result": hook_result}
-            except (RuntimeError, ValueError, TypeError, OSError) as e:
-                return {"success": False, "hook_name": hook_name, "error": str(e)}
+            except (RuntimeError, ValueError, TypeError, OSError) as exc:
+                return {"success": False, "hook_name": hook_name, "error": str(exc)}
 
     return {
         "success": False,
@@ -98,7 +96,7 @@ def execute_single_hook(
     }
 
 
-def validate_hooks(hook_type: Union[str, "HookType"], platform: Optional[str] = None) -> Dict[str, Any]:
+def validate_hooks(hook_type: HookTypeLike, platform: Optional[str] = None) -> Dict[str, Any]:
     """
     Validate that all hooks for a type can be loaded without errors.
 
@@ -109,7 +107,7 @@ def validate_hooks(hook_type: Union[str, "HookType"], platform: Optional[str] = 
     Returns:
         Dictionary containing validation results
     """
-    hooks = get_hooks(hook_type, platform)
+    hooks: list[HookInfo] = get_hooks(hook_type, platform)
 
     validation_results: Dict[str, Any] = {
         "valid": True,
@@ -120,49 +118,138 @@ def validate_hooks(hook_type: Union[str, "HookType"], platform: Optional[str] = 
 
     for hook_info in hooks:
         hook_name = hook_info["name"]
-        hook_func = hook_info["func"]
 
         try:
-            # Try to get function signature to validate it can be called
-            import inspect
-
-            sig = inspect.signature(hook_func)
-
-            # Check if function accepts context parameter
-            if "context" in sig.parameters or len(sig.parameters) > 0:
-                validation_results["valid_hooks"].append(
-                    {"name": hook_name, "description": hook_info.get("description", "")}
-                )
-            else:
+            invocation = hook_info.get("invocation", "positional")
+            if invocation == "no_args":
                 validation_results["invalid_hooks"].append(
                     {"name": hook_name, "error": "Function must accept at least one parameter"}
                 )
                 validation_results["valid"] = False
+            else:
+                entry = {"name": hook_name, "description": hook_info.get("description", "")}
+                if invocation == "unknown":
+                    entry["note"] = "Signature inspection unavailable"
+                validation_results["valid_hooks"].append(entry)
 
-        except (RuntimeError, ValueError, TypeError, OSError) as e:
-            validation_results["invalid_hooks"].append({"name": hook_name, "error": f"Validation error: {str(e)}"})
+        except (RuntimeError, ValueError, TypeError, OSError) as exc:
+            validation_results["invalid_hooks"].append({"name": hook_name, "error": f"Validation error: {str(exc)}"})
             validation_results["valid"] = False
 
     return validation_results
 
 
+def _invoke_hook(hook_info: HookInfo, context: Dict[str, Any]) -> Any:
+    """Invoke a hook using the preferred calling convention captured at registration."""
+
+    hook_func = hook_info["func"]
+    summary: HookSignatureSummary | None = hook_info.get("signature_summary")
+
+    if summary:
+        return _invoke_with_signature_summary(hook_info, summary, context)
+
+    invocation = hook_info.get("invocation", "positional")
+
+    if invocation == "no_args":
+        return hook_func()
+    if invocation == "context_keyword":
+        return hook_func(context=context)
+    if invocation == "kwargs":
+        return hook_func(**context)
+
+    # Default behaviour matches the historical calling convention
+    return hook_func(context)
+
+
+def _invoke_with_signature_summary(
+    hook_info: HookInfo, summary: HookSignatureSummary, context: Dict[str, Any]
+) -> Any:
+    """Construct arguments based on a captured signature summary and invoke the hook."""
+
+    hook_func = hook_info["func"]
+    signature = summary.signature
+
+    if not signature.parameters:
+        return hook_func()
+
+    context_param = summary.context_parameter
+    positional_arguments: list[Any] = []
+    keyword_arguments: Dict[str, Any] = {}
+    remaining_context: Dict[str, Any] = dict(context)
+
+    for parameter in signature.parameters.values():
+        name = parameter.name
+        kind = parameter.kind
+
+        if parameter is context_param:
+            if kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            ):
+                positional_arguments.append(context)
+            elif kind == inspect.Parameter.KEYWORD_ONLY:
+                keyword_arguments[name] = context
+            elif kind == inspect.Parameter.VAR_POSITIONAL:
+                positional_arguments.append(context)
+            elif kind == inspect.Parameter.VAR_KEYWORD:
+                keyword_arguments.update(remaining_context)
+                remaining_context.clear()
+            remaining_context.pop(name, None)
+            continue
+
+        if kind == inspect.Parameter.VAR_POSITIONAL:
+            continue
+
+        if kind == inspect.Parameter.VAR_KEYWORD:
+            keyword_arguments.update(remaining_context)
+            remaining_context.clear()
+            continue
+
+        if name in remaining_context:
+            value = remaining_context.pop(name)
+            if kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            ):
+                positional_arguments.append(value)
+            else:
+                keyword_arguments[name] = value
+            continue
+
+        if parameter.default is not inspect.Signature.empty:
+            if kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            ):
+                positional_arguments.append(parameter.default)
+            else:
+                keyword_arguments[name] = parameter.default
+            continue
+
+        raise TypeError(
+            f"Missing required context value '{name}' for hook '{hook_info['name']}'"
+        )
+
+    return hook_func(*positional_arguments, **keyword_arguments)
+
+
 # Convenience functions for common operations
 def execute_global_hooks(
-    hook_type: Union[str, "HookType"], context: Dict[str, Any], stop_on_error: bool = False
+    hook_type: HookTypeLike, context: Dict[str, Any], stop_on_error: bool = False
 ) -> bool:
     """Execute only global hooks for a type."""
     return execute_hooks(hook_type, context, None, stop_on_error)
 
 
 def execute_platform_hooks(
-    hook_type: Union[str, "HookType"], context: Dict[str, Any], platform: str, stop_on_error: bool = False
+    hook_type: HookTypeLike, context: Dict[str, Any], platform: str, stop_on_error: bool = False
 ) -> bool:
     """Execute only platform-specific hooks for a type and platform."""
     return execute_hooks(hook_type, context, platform, stop_on_error)
 
 
 def execute_hooks_with_fallback(
-    hook_type: Union[str, "HookType"],
+    hook_type: HookTypeLike,
     context: Dict[str, Any],
     platform: Optional[str] = None,
     fallback_to_global: bool = True,

--- a/src/plugins/patch_override.py
+++ b/src/plugins/patch_override.py
@@ -1,6 +1,6 @@
-"""
-Patch and override operations for project management.
-"""
+"""Patch and override operations for project management."""
+
+from __future__ import annotations
 
 import fnmatch
 import os
@@ -16,7 +16,7 @@ from src.operations.registry import register
 # from src.profiler import auto_profile  # unused
 
 
-def parse_po_config(po_config):
+def parse_po_config(po_config: str) -> Tuple[List[str], set[str], Dict[str, set[str]]]:
     """Parse PROJECT_PO_CONFIG string into components.
 
     Returns a tuple of (apply_pos: list[str], exclude_pos: set[str], exclude_files: dict[str, set[str]]).

--- a/src/plugins/project_builder.py
+++ b/src/plugins/project_builder.py
@@ -35,7 +35,7 @@ def _safe_run(cmd: Sequence[str], cwd: Path, *, capture_output: bool = False) ->
 
     return subprocess.run(
         list(cmd),
-        cwd=str(cwd),
+        cwd=os.fspath(cwd),
         stdout=subprocess.PIPE if capture_output else subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         check=True,
@@ -107,7 +107,7 @@ def project_diff(env: Dict, projects_info: Dict, project_name: str, keep_diff_di
                     commit_hash = (
                         subprocess.check_output(
                             ["git", "rev-parse", f"{ref}:{file_path}"],
-                            cwd=str(repo_path),
+                            cwd=os.fspath(repo_path),
                             stderr=subprocess.DEVNULL,
                         )
                         .decode()
@@ -118,7 +118,7 @@ def project_diff(env: Dict, projects_info: Dict, project_name: str, keep_diff_di
                     with out_file.open("wb") as handle:
                         subprocess.run(
                             ["git", "show", f"{ref}:{file_path}"],
-                            cwd=str(repo_path),
+                            cwd=os.fspath(repo_path),
                             stdout=handle,
                             stderr=subprocess.DEVNULL,
                             check=True,
@@ -138,12 +138,12 @@ def project_diff(env: Dict, projects_info: Dict, project_name: str, keep_diff_di
         try:
             upstream = subprocess.check_output(
                 ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
-                cwd=str(repo_path),
+                cwd=os.fspath(repo_path),
                 stderr=subprocess.DEVNULL,
             ).decode().strip()
             commits = subprocess.check_output(
                 ["git", "rev-list", f"{upstream}..HEAD"],
-                cwd=str(repo_path),
+                cwd=os.fspath(repo_path),
                 stderr=subprocess.DEVNULL,
             ).decode().strip().splitlines()
             if not commits:
@@ -151,7 +151,7 @@ def project_diff(env: Dict, projects_info: Dict, project_name: str, keep_diff_di
             out_dir.mkdir(parents=True, exist_ok=True)
             subprocess.run(
                 ["git", "format-patch", f"{upstream}..HEAD", "-o", str(out_dir)],
-                cwd=str(repo_path),
+                cwd=os.fspath(repo_path),
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 check=True,
@@ -168,7 +168,7 @@ def project_diff(env: Dict, projects_info: Dict, project_name: str, keep_diff_di
         print(f"Processing repo {idx + 1}/{len(repositories)}: {repo_name}")
         repo_path_obj = Path(repo_path)
         staged_files = (
-            subprocess.check_output(["git", "diff", "--name-only", "--cached"], cwd=repo_path)
+            subprocess.check_output(["git", "diff", "--name-only", "--cached"], cwd=os.fspath(repo_path))
             .decode()
             .strip()
             .splitlines()
@@ -176,7 +176,7 @@ def project_diff(env: Dict, projects_info: Dict, project_name: str, keep_diff_di
         working_files = (
             subprocess.check_output(
                 ["git", "ls-files", "--modified", "--others", "--exclude-standard"],
-                cwd=repo_path,
+                cwd=os.fspath(repo_path),
             )
             .decode()
             .strip()

--- a/src/plugins/project_builder.py
+++ b/src/plugins/project_builder.py
@@ -1,13 +1,15 @@
-"""
-Project build utility class for CLI operations.
-"""
+"""Project build utility class for CLI operations."""
+
+from __future__ import annotations
 
 import os
 import shutil
 import subprocess
 import tarfile
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, Optional
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Sequence
 
 from src.hooks import HookType, execute_hooks_with_fallback
 from src.log_manager import log
@@ -17,167 +19,139 @@ from src.operations.registry import register
 from src.plugins.patch_override import po_apply
 
 
+@dataclass(frozen=True)
+class DiffLayout:
+    """Path layout for generated diff artefacts."""
+
+    root: Path
+    after: Path
+    before: Path
+    patch: Path
+    commit: Path
+
+
+def _safe_run(cmd: Sequence[str], cwd: Path, *, capture_output: bool = False) -> subprocess.CompletedProcess:
+    """Run a git command, raising errors with suppressed stderr noise."""
+
+    return subprocess.run(
+        list(cmd),
+        cwd=str(cwd),
+        stdout=subprocess.PIPE if capture_output else subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
 @register(
     "project_diff",
     needs_repositories=True,
     desc="Generate after, before, patch, commit directories for all repositories or current repo, under a timestamped diff directory.",
 )
 def project_diff(env: Dict, projects_info: Dict, project_name: str, keep_diff_dir: bool = False) -> bool:
-    """
-    Generate after, before, patch, commit directories for all repositories or current repo, under a timestamped diff directory.
-    Patch files are named changes_worktree.patch and changes_staged.patch.
-    If single repo, do not create root subdirectory, put files directly under after, before, etc.
-    Diff directory is .cache/build/{project_name}/{timestamp}/diff
+    """Generate snapshots, patches, and commit exports for all repositories."""
 
-    Args:
-        env: Environment variables and configuration
-        projects_info: Project information dictionary
-        project_name: Name of the project
-        keep_diff_dir (bool): If True, preserve the diff directory after creating tar.gz archive (default: False)
-    """
-    _ = projects_info  # Mark as intentionally unused
+    _ = projects_info
 
-    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     safe_project_name = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in str(project_name))
 
-    # Use absolute path to create diff_root in project root directory
-    root_dir = os.getcwd()  # Store project root directory
-    diff_root = os.path.join(root_dir, ".cache", "build", safe_project_name, ts, "diff")
+    root_dir = Path.cwd()
+    diff_root = root_dir / ".cache" / "build" / safe_project_name / timestamp / "diff"
     log.debug("Diff root directory: %s", diff_root)
-    os.makedirs(diff_root, exist_ok=True)
+    diff_root.mkdir(parents=True, exist_ok=True)
+
+    layout = DiffLayout(
+        root=diff_root,
+        after=diff_root / "after",
+        before=diff_root / "before",
+        patch=diff_root / "patch",
+        commit=diff_root / "commit",
+    )
 
     repositories = env.get("repositories", [])
     single_repo = len(repositories) == 1
 
-    def is_tracked(repo_path, file_path):
+    def is_tracked(repo_path: Path, file_path: str) -> bool:
         try:
-            result = subprocess.run(
-                ["git", "ls-files", "--error-unmatch", file_path],
-                cwd=repo_path,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                check=True,
-            )
-            return result.returncode == 0
+            _safe_run(["git", "ls-files", "--error-unmatch", file_path], repo_path)
+            return True
         except (OSError, subprocess.SubprocessError):
             return False
 
-    def save_file_snapshot(repo_path, file_path, out_dir, ref=None):
-        abs_file = os.path.join(repo_path, file_path)
-        out_file = os.path.join(out_dir, file_path)
-        os.makedirs(os.path.dirname(out_file), exist_ok=True)
+    def save_file_snapshot(repo_path: Path, file_path: str, out_dir: Path, ref: Optional[str] = None) -> None:
+        abs_file = repo_path / file_path
+        out_file = out_dir / file_path
+        out_file.parent.mkdir(parents=True, exist_ok=True)
         if ref is None:
-            if os.path.exists(abs_file):
-                if os.path.isfile(abs_file):
+            if abs_file.exists():
+                if abs_file.is_file():
                     shutil.copy2(abs_file, out_file)
-                elif os.path.isdir(abs_file):
-                    # For directories, copy the entire directory tree
-                    if os.path.exists(out_file):
+                elif abs_file.is_dir():
+                    if out_file.exists():
                         shutil.rmtree(out_file)
 
-                    # Exclude .git directory when copying
-                    def ignore_git(directory, files):
-                        _ = directory
-                        _ = files
-                        return [".git"]
+                    def ignore_git(_: str, __: Iterable[str]) -> Sequence[str]:
+                        return (".git",)
 
                     shutil.copytree(abs_file, out_file, ignore=ignore_git)
-        else:
-            if is_tracked(repo_path, file_path):
-                try:
-                    # Check if this is a submodule
-                    result = subprocess.run(
-                        ["git", "ls-files", "--stage", file_path],
-                        cwd=repo_path,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.DEVNULL,
-                        check=True,
-                    )
-                    mode = result.stdout.decode().split()[0]
-
-                    if mode == "160000":  # This is a submodule
-                        # For submodules, create a file with the commit hash
-                        commit_hash = (
-                            subprocess.check_output(
-                                ["git", "rev-parse", f"{ref}:{file_path}"],
-                                cwd=repo_path,
-                                stderr=subprocess.DEVNULL,
-                            )
-                            .decode()
-                            .strip()
+        elif is_tracked(repo_path, file_path):
+            try:
+                result = _safe_run(["git", "ls-files", "--stage", file_path], repo_path, capture_output=True)
+                mode = result.stdout.decode().split()[0]
+                if mode == "160000":
+                    commit_hash = (
+                        subprocess.check_output(
+                            ["git", "rev-parse", f"{ref}:{file_path}"],
+                            cwd=str(repo_path),
+                            stderr=subprocess.DEVNULL,
                         )
-                        with open(out_file, "w", encoding="utf-8") as f:
-                            f.write(f"Subproject commit {commit_hash}\n")
-                    else:
-                        # Regular file
-                        with open(out_file, "wb") as f:
-                            subprocess.run(
-                                ["git", "show", f"{ref}:{file_path}"],
-                                cwd=repo_path,
-                                stdout=f,
-                                stderr=subprocess.DEVNULL,
-                                check=True,
-                            )
-                except subprocess.CalledProcessError:
-                    # File doesn't exist in the specified ref, skip it
-                    pass
+                        .decode()
+                        .strip()
+                    )
+                    _write_text(out_file, f"Subproject commit {commit_hash}\n")
+                else:
+                    with out_file.open("wb") as handle:
+                        subprocess.run(
+                            ["git", "show", f"{ref}:{file_path}"],
+                            cwd=str(repo_path),
+                            stdout=handle,
+                            stderr=subprocess.DEVNULL,
+                            check=True,
+                        )
+            except subprocess.CalledProcessError:
+                pass
 
-    def save_patch(repo_path, file_paths, out_dir, patch_name, staged=False):
-        if staged:
-            cmd = ["git", "diff", "--cached"] + file_paths
-        else:
-            cmd = ["git", "diff"] + file_paths
-
-        # Get diff content first
-        result = subprocess.run(
-            cmd,
-            cwd=repo_path,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            check=True,
-        )
+    def save_patch(repo_path: Path, file_paths: Sequence[str], out_dir: Path, patch_name: str, staged: bool = False) -> None:
+        cmd = ["git", "diff", "--cached"] if staged else ["git", "diff"]
+        cmd.extend(file_paths)
+        result = _safe_run(cmd, repo_path, capture_output=True)
         patch_content = result.stdout.decode("utf-8")
-
-        # Only create file if patch content is not empty
         if patch_content.strip():
-            out_file = os.path.join(out_dir, patch_name)
-            os.makedirs(os.path.dirname(out_file), exist_ok=True)
-            with open(out_file, "w", encoding="utf-8") as f:
-                f.write(patch_content)
+            _write_text(out_dir / patch_name, patch_content)
 
-    def save_commits(repo_path, out_dir):
+    def save_commits(repo_path: Path, out_dir: Path) -> None:
         try:
-            upstream = (
-                subprocess.check_output(
-                    [
-                        "git",
-                        "rev-parse",
-                        "--abbrev-ref",
-                        "--symbolic-full-name",
-                        "@{u}",
-                    ],
-                    cwd=repo_path,
-                    stderr=subprocess.DEVNULL,
-                )
-                .decode()
-                .strip()
-            )
-            commits = (
-                subprocess.check_output(
-                    ["git", "rev-list", f"{upstream}..HEAD"],
-                    cwd=repo_path,
-                    stderr=subprocess.DEVNULL,
-                )
-                .decode()
-                .strip()
-                .splitlines()
-            )
+            upstream = subprocess.check_output(
+                ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+                cwd=str(repo_path),
+                stderr=subprocess.DEVNULL,
+            ).decode().strip()
+            commits = subprocess.check_output(
+                ["git", "rev-list", f"{upstream}..HEAD"],
+                cwd=str(repo_path),
+                stderr=subprocess.DEVNULL,
+            ).decode().strip().splitlines()
             if not commits:
                 return
-            os.makedirs(out_dir, exist_ok=True)
+            out_dir.mkdir(parents=True, exist_ok=True)
             subprocess.run(
-                ["git", "format-patch", f"{upstream}..HEAD", "-o", out_dir],
-                cwd=repo_path,
+                ["git", "format-patch", f"{upstream}..HEAD", "-o", str(out_dir)],
+                cwd=str(repo_path),
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 check=True,
@@ -185,80 +159,66 @@ def project_diff(env: Dict, projects_info: Dict, project_name: str, keep_diff_di
         except (OSError, subprocess.SubprocessError):
             pass
 
-    for d in ["after", "before", "patch", "commit"]:
-        dpath = os.path.join(diff_root, d)
-        if os.path.exists(dpath):
-            shutil.rmtree(dpath)
-        os.makedirs(dpath, exist_ok=True)
+    for directory in (layout.after, layout.before, layout.patch, layout.commit):
+        if directory.exists():
+            shutil.rmtree(directory)
+        directory.mkdir(parents=True, exist_ok=True)
 
     for idx, (repo_path, repo_name) in enumerate(repositories):
         print(f"Processing repo {idx + 1}/{len(repositories)}: {repo_name}")
-        original_cwd = os.getcwd()
-        os.chdir(repo_path)
-        staged_files = subprocess.check_output(["git", "diff", "--name-only", "--cached"]).decode().strip().splitlines()
-        working_files = (
-            subprocess.check_output(["git", "ls-files", "--modified", "--others", "--exclude-standard"])
+        repo_path_obj = Path(repo_path)
+        staged_files = (
+            subprocess.check_output(["git", "diff", "--name-only", "--cached"], cwd=repo_path)
             .decode()
             .strip()
             .splitlines()
         )
-        all_files = set(staged_files) | set(working_files)
-        file_list = [f for f in all_files if f.strip()]
-        # Target directory: single repo put files directly under diff_root/after, etc.; multi-repo use repo_name subdirectory
-        if single_repo:
-            after_dir = os.path.join(diff_root, "after")
-            before_dir = os.path.join(diff_root, "before")
-            patch_dir = os.path.join(diff_root, "patch")
-            commit_dir = os.path.join(diff_root, "commit")
-        else:
-            after_dir = os.path.join(diff_root, "after", repo_name)
-            before_dir = os.path.join(diff_root, "before", repo_name)
-            patch_dir = os.path.join(diff_root, "patch", repo_name)
-            commit_dir = os.path.join(diff_root, "commit", repo_name)
-        for file_path in file_list:
-            save_file_snapshot(repo_path, file_path, after_dir)
-            save_file_snapshot(repo_path, file_path, before_dir, ref="HEAD")
-        if file_list:
-            save_patch(
-                repo_path,
-                file_list,
-                patch_dir,
-                "changes_worktree.patch",
-                staged=False,
+        working_files = (
+            subprocess.check_output(
+                ["git", "ls-files", "--modified", "--others", "--exclude-standard"],
+                cwd=repo_path,
             )
-            save_patch(repo_path, file_list, patch_dir, "changes_staged.patch", staged=True)
-        save_commits(repo_path, commit_dir)
-        os.chdir(original_cwd)
+            .decode()
+            .strip()
+            .splitlines()
+        )
+        file_paths = sorted({path for path in staged_files + working_files if path.strip()})
 
-    # Create tar.gz archive of the diff directory
+        if single_repo:
+            repo_after = layout.after
+            repo_before = layout.before
+            repo_patch = layout.patch
+            repo_commit = layout.commit
+        else:
+            repo_after = layout.after / repo_name
+            repo_before = layout.before / repo_name
+            repo_patch = layout.patch / repo_name
+            repo_commit = layout.commit / repo_name
+
+        for file_path in file_paths:
+            save_file_snapshot(repo_path_obj, file_path, repo_after)
+            save_file_snapshot(repo_path_obj, file_path, repo_before, ref="HEAD")
+
+        if file_paths:
+            save_patch(repo_path_obj, file_paths, repo_patch, "changes_worktree.patch", staged=False)
+            save_patch(repo_path_obj, file_paths, repo_patch, "changes_staged.patch", staged=True)
+        save_commits(repo_path_obj, repo_commit)
+
     try:
-        # Get the parent directory of diff_root (the timestamp directory)
-        timestamp_dir = os.path.dirname(diff_root)
-        archive_name = f"diff_{safe_project_name}_{ts}.tar.gz"
-        archive_path = os.path.join(timestamp_dir, archive_name)
-
+        timestamp_dir = diff_root.parent
+        archive_name = f"diff_{safe_project_name}_{timestamp}.tar.gz"
+        archive_path = timestamp_dir / archive_name
         log.info("Creating tar.gz archive: %s", archive_path)
-
         with tarfile.open(archive_path, "w:gz") as tar:
-            # Add the diff directory to the archive
-            tar.add(diff_root, arcname=os.path.basename(diff_root))
-
+            tar.add(str(diff_root), arcname=diff_root.name)
         log.info("Successfully created tar.gz archive: %s", archive_path)
-
-        # Check keep_diff_dir parameter to determine whether to delete the diff directory
-        # Default behavior: delete the diff directory after archiving
-        # Use --keep-diff-dir flag to preserve the diff directory
-
         if not keep_diff_dir:
-            # Remove the original diff directory after archiving (default behavior)
             shutil.rmtree(diff_root)
             log.info("Removed original diff directory after archiving")
         else:
             log.info("Keeping original diff directory as per --keep-diff-dir flag")
-
-    except (OSError, tarfile.TarError, RuntimeError) as e:
-        log.error("Failed to create tar.gz archive: %s", e)
-        # Continue execution even if archiving fails
+    except (OSError, tarfile.TarError, RuntimeError) as exc:
+        log.error("Failed to create tar.gz archive: %s", exc)
 
     return True
 
@@ -269,11 +229,9 @@ def project_diff(env: Dict, projects_info: Dict, project_name: str, keep_diff_di
     desc="Pre-build stage for the specified project.",
 )
 def project_pre_build(env: Dict, projects_info: Dict, project_name: str) -> bool:
-    """
-    Pre-build stage for the specified project.
-    """
+    """Pre-build stage for the specified project."""
+
     log.info("Pre-build stage for project: %s", project_name)
-    # Apply patch/override; failures are fatal
     try:
         result = po_apply(env, projects_info, project_name)
         if not result:
@@ -292,11 +250,9 @@ def project_pre_build(env: Dict, projects_info: Dict, project_name: str) -> bool
     desc="Build stage for the specified project.",
 )
 def project_do_build(env: Dict, projects_info: Dict, project_name: str) -> bool:
-    """
-    Build stage for the specified project.
-    """
+    """Build stage for the specified project."""
+
     log.info("Build stage for project: %s", project_name)
-    # TODO: implement build logic
     _ = env
     _ = projects_info
     return True
@@ -308,11 +264,9 @@ def project_do_build(env: Dict, projects_info: Dict, project_name: str) -> bool:
     desc="Post-build stage for the specified project.",
 )
 def project_post_build(env: Dict, projects_info: Dict, project_name: str) -> bool:
-    """
-    Post-build stage for the specified project.
-    """
+    """Post-build stage for the specified project."""
+
     log.info("Post-build stage for project: %s", project_name)
-    # TODO: implement post-build logic
     _ = env
     _ = projects_info
     return True
@@ -324,79 +278,62 @@ def project_post_build(env: Dict, projects_info: Dict, project_name: str) -> boo
     desc="Build the specified project, including pre-build, build, and post-build stages.",
 )
 def project_build(env: Dict, projects_info: Dict, project_name: str) -> bool:
-    """
-    Build the specified project, including pre-build, build, and post-build stages.
+    """Build the specified project and execute relevant hooks."""
 
-    Args:
-        env: Environment variables and configuration
-        projects_info: Project information dictionary
-        project_name: Name of the project to build
-    """
-    # Get platform from project_info
     project_info = projects_info.get(project_name, {})
     platform = project_info.get("config", {}).get("PROJECT_PLATFORM")
 
-    def create_context(env: Dict, projects_info: Dict, project_name: str, platform: Optional[str] = None) -> Dict:
-        """Create context dictionary for hooks."""
+    def create_context(platform_name: Optional[str] = None) -> Dict:
         return {
             "env": env,
             "projects_info": projects_info,
             "project_name": project_name,
-            "platform": platform,
+            "platform": platform_name,
             "timestamp": datetime.now().isoformat(),
         }
 
-    def has_platform_hooks(hook_type: HookType, platform: str) -> bool:
-        """Check if there are any hooks registered for the specified platform and hook type."""
-        from src.hooks.registry import _platform_hooks
+    def has_platform_hooks(hook_type: HookType, platform_name: str) -> bool:
+        from src.hooks.registry import _platform_hooks  # pylint: disable=protected-access
 
-        return platform in _platform_hooks and hook_type.value in _platform_hooks[platform]
+        platform_hooks = _platform_hooks.get(platform_name, {})
+        return bool(platform_hooks.get(hook_type.value))
 
-    # Create a single shared context for the entire build process
-    shared_context = create_context(env, projects_info, project_name, platform)
+    shared_context = create_context(platform)
 
-    # Execute validation hooks if platform is specified and has hooks
     if platform and has_platform_hooks(HookType.VALIDATION, platform):
         validation_result = execute_hooks_with_fallback(HookType.VALIDATION, shared_context, platform)
         if not validation_result:
             log.error("Validation hooks failed, aborting build")
             return False
 
-    # Execute pre-build stage
     if not project_pre_build(env, projects_info, project_name):
         log.error("Pre-build failed for project: %s", project_name)
         return False
 
-    # Execute pre-build hooks if platform is specified and has hooks
     if platform and has_platform_hooks(HookType.PRE_BUILD, platform):
         pre_build_result = execute_hooks_with_fallback(HookType.PRE_BUILD, shared_context, platform)
         if not pre_build_result:
             log.error("Pre-build hooks failed, aborting build")
             return False
 
-    # Execute build hooks if platform is specified and has hooks
     if platform and has_platform_hooks(HookType.BUILD, platform):
         build_result = execute_hooks_with_fallback(HookType.BUILD, shared_context, platform)
         if not build_result:
             log.error("Build hooks failed, aborting build")
             return False
 
-    # Execute build stage
     if not project_do_build(env, projects_info, project_name):
         log.error("Build failed for project: %s", project_name)
         return False
 
-    # Execute post-build hooks if platform is specified and has hooks
     if platform and has_platform_hooks(HookType.POST_BUILD, platform):
         post_build_result = execute_hooks_with_fallback(HookType.POST_BUILD, shared_context, platform)
         if not post_build_result:
             log.error("Post-build hooks failed, aborting build")
             return False
 
-    # Execute post-build stage
     if not project_post_build(env, projects_info, project_name):
         log.error("Post-build failed for project: %s", project_name)
         return False
 
-    log.info("Build succeeded for project: %s", project_name)
     return True

--- a/src/plugins/project_manager.py
+++ b/src/plugins/project_manager.py
@@ -1,10 +1,14 @@
 """Project management utility class for CLI operations."""
 
+from __future__ import annotations
+
 import json
 import os
 import shutil
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, List
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
 
 from configupdater import ConfigUpdater
 
@@ -12,73 +16,99 @@ from src.log_manager import log
 from src.operations.registry import register
 
 
+@dataclass(frozen=True)
+class BoardContext:
+    """Resolved context for an existing board."""
+
+    board_name: str
+    board_path: Path
+    ini_path: Path
+
+
+def _existing_board_context(project_name: str, projects_info: Dict[str, Dict]) -> Optional[BoardContext]:
+    info = projects_info.get(project_name)
+    if not isinstance(info, dict):
+        return None
+    board_name = info.get("board_name")
+    board_path = info.get("board_path")
+    ini_file = info.get("ini_file")
+    if not (board_name and board_path and ini_file):
+        return None
+    return BoardContext(board_name=str(board_name), board_path=Path(board_path), ini_path=Path(ini_file))
+
+
+def _safe_access(path: Path, mode: int) -> bool:
+    try:
+        return os.access(path, mode)
+    except OSError:
+        return False
+
+
+def _normalise_board_name(board_name: str) -> Optional[str]:
+    if not isinstance(board_name, str) or not board_name.strip():
+        return None
+    name = board_name.strip()
+    if name in {".", ".."}:
+        return None
+    normalised = os.path.normpath(name)
+    if normalised in {".", ".."} or os.path.isabs(normalised):
+        return None
+    if any(sep in name for sep in (os.sep, os.altsep) if sep):
+        return None
+    return normalised
+
+
+def _reserved_board_name(board_name: str) -> bool:
+    return board_name in {"common", "template", "scripts", ".cache", ".git"}
+
+
 @register("project_new", needs_repositories=False, desc="Create a new project.")
 def project_new(env: Dict, projects_info: Dict, project_name: str) -> bool:
-    """
-    Create a new project.
-    Args:
-        env (dict): Global environment dict.
-        projects_info (dict): All projects info.
-        project_name (str): Project name. Must be provided.
-    """
+    """Create a new project entry inside an existing board."""
+
+    if not isinstance(projects_info, dict):
+        log.error("projects_info must be a dictionary for project_new.")
+        print("Error: projects_info must be a dictionary.")
+        return False
 
     _ = env
 
-    def find_parent_project(name):
-        if "-" in name:
-            return name.rsplit("-", 1)[0]
-        return None
+    def find_parent(name: str) -> Optional[str]:
+        return name.rsplit("-", 1)[0] if "-" in name else None
 
-    def get_inherited_config(projects_info, name):
-        config = {}
-        parent = find_parent_project(name)
-        if parent and parent in projects_info:
-            config.update(get_inherited_config(projects_info, parent))
+    def inherited_config(name: str) -> Dict:
+        config: Dict = {}
+        parent = find_parent(name)
+        if parent:
+            config.update(inherited_config(parent))
         if name in projects_info:
             config.update(projects_info[name])
         return config
 
-    def find_board_for_project(project_name, projects_info):
-        """
-        Find the appropriate board for a new project based on parent project or project name pattern.
-        """
-        # First, try to find parent project to determine board
-        parent = find_parent_project(project_name)
+    def candidate_contexts() -> Iterable[BoardContext]:
+        parent = find_parent(project_name)
         if parent:
-            # If project name suggests a parent (contains "-"),
-            # the parent MUST exist in projects_info
-            if parent in projects_info:
-                parent_cfg = projects_info[parent]
-                return (
-                    parent_cfg.get("board_name"),
-                    parent_cfg.get("board_path"),
-                    parent_cfg.get("ini_file"),
-                )
-            return None, None, None
+            context = _existing_board_context(parent, projects_info)
+            if context:
+                yield context
+            return
+        for existing_project in projects_info:
+            if project_name.startswith(f"{existing_project}-"):
+                context = _existing_board_context(existing_project, projects_info)
+                if context:
+                    yield context
 
-        # If no parent found, try to infer board from project name pattern
-        # Look for existing projects with similar naming patterns
-        for existing_project, project_info in projects_info.items():
-            if project_name.startswith(existing_project + "-"):
-                return (
-                    project_info.get("board_name"),
-                    project_info.get("board_path"),
-                    project_info.get("ini_file"),
-                )
-        # No fallback strategy - if we can't determine board, return None
-        return None, None, None
-
-    # Find board information for the new project
-    board_name, board_path, ini_file = find_board_for_project(project_name, projects_info)
     if not project_name:
         log.error("Project name must be provided.")
         print("Error: Project name must be provided.")
         return False
-    if not board_name or not board_path:
+
+    context = next(candidate_contexts(), None)
+    if context is None:
         log.error("Cannot determine board for project '%s'. Please ensure:", project_name)
         print(f"Error: Cannot determine board for project '{project_name}'. Please ensure:")
         if "-" in project_name:
-            parent = find_parent_project(project_name)
+            parent = find_parent(project_name)
             print(f"  1. Parent project '{parent}' exists in projects_info")
             print("  2. The parent project is properly configured with board information")
         else:
@@ -86,50 +116,47 @@ def project_new(env: Dict, projects_info: Dict, project_name: str) -> bool:
             print("  2. The project name follows the pattern 'parent-project'")
             print("  3. There are available board directories in projects")
         return False
-    if not os.path.isdir(board_path):
-        log.error(
-            "Board directory '%s' does not exist for project '%s'.",
-            board_name,
-            project_name,
-        )
+
+    board_name = context.board_name
+    board_path = context.board_path
+    ini_file = context.ini_path
+
+    if not board_path.is_dir():
+        log.error("Board directory '%s' does not exist for project '%s'.", board_name, project_name)
         print(f"Error: Board directory '{board_name}' does not exist for project '{project_name}'.")
         return False
-    if not ini_file:
+    if not ini_file.exists():
         log.error("No ini file found for board: '%s'", board_name)
         print(f"No ini file found for board: '{board_name}'")
         return False
-
-    # project_name cannot be the same as board_name (board section is not a project)
     if project_name == board_name:
         log.error("Project name '%s' cannot be the same as board name.", project_name)
         print(f"Error: Project name '{project_name}' cannot be the same as board name.")
         return False
 
-    # Check for duplicate project
     config = ConfigUpdater()
     config.optionxform = str
     try:
-        # Ensure ini file is readable
-        if not os.access(ini_file, os.R_OK):
+        if not _safe_access(ini_file, os.R_OK):
             log.error("INI file is not readable: '%s'", ini_file)
             print(f"Error: INI file is not readable: '{ini_file}'")
             return False
-        config.read(ini_file, encoding="utf-8")
+        config.read(str(ini_file), encoding="utf-8")
     except (PermissionError, OSError, UnicodeError) as err:
         log.error("Failed to read INI file '%s': %s", ini_file, err)
         print(f"Error: Failed to read INI file '{ini_file}': {err}")
         return False
+
     if project_name in config.sections():
         log.error("Project '%s' already exists in board '%s'.", project_name, board_name)
         print(f"Project '{project_name}' already exists in board '{board_name}'.")
         return False
 
-    # Recursively inherit configuration
-    inherited_config = get_inherited_config(projects_info, project_name)
-    parent_config = inherited_config.get("config", {}) if isinstance(inherited_config.get("config", {}), dict) else {}
+    inherited = inherited_config(project_name)
+    parent_config = inherited.get("config", {}) if isinstance(inherited.get("config", {}), dict) else {}
     platform_name = parent_config.get("PROJECT_PLATFORM")
     project_customer = parent_config.get("PROJECT_CUSTOMER")
-    project_name_parts = []
+    project_name_parts: List[str] = []
     if platform_name:
         project_name_parts.append(platform_name)
     project_name_parts.append(project_name)
@@ -137,22 +164,19 @@ def project_new(env: Dict, projects_info: Dict, project_name: str) -> bool:
         project_name_parts.append(project_customer)
     project_name_value = "_".join(project_name_parts)
 
-    # Read the original ini file content to preserve comments and formatting
     try:
-        if not os.access(ini_file, os.R_OK):
+        if not _safe_access(ini_file, os.R_OK):
             log.error("INI file is not readable: '%s'", ini_file)
             print(f"Error: INI file is not readable: '{ini_file}'")
             return False
-        with open(ini_file, "r", encoding="utf-8") as f:
-            original_lines = f.readlines()
+        original_lines = ini_file.read_text(encoding="utf-8").splitlines(keepends=True)
     except (PermissionError, OSError, UnicodeError) as err:
         log.error("Failed to read INI file '%s': %s", ini_file, err)
         print(f"Error: Failed to read INI file '{ini_file}': {err}")
         return False
 
-    # Rewrite only the board's PROJECT_NAME assignment to have spaces around '=' and keep comments intact
-    new_lines = []
-    current_section = None
+    new_lines: List[str] = []
+    current_section: Optional[str] = None
     for line in original_lines:
         stripped = line.strip()
         if stripped.startswith("[") and stripped.endswith("]"):
@@ -162,41 +186,32 @@ def project_new(env: Dict, projects_info: Dict, project_name: str) -> bool:
         if current_section == board_name:
             lstrip = line.lstrip()
             if lstrip.upper().startswith("PROJECT_NAME") and "=" in line:
-                # Preserve leading indentation and any trailing inline comment
                 prefix_len = len(line) - len(lstrip)
                 prefix = line[:prefix_len]
                 _after = line.split("=", 1)[1]
-                # Keep everything after '=' including inline comments/spaces
                 new_lines.append(f"{prefix}PROJECT_NAME = {_after.lstrip()}")
                 continue
         new_lines.append(line)
 
-    # Ensure a single blank line before appending the new section
-    if new_lines and new_lines[-1].strip() != "":
+    if new_lines and new_lines[-1].strip():
         new_lines.append("\n")
-    elif len(new_lines) >= 2 and new_lines[-1].strip() == "" and new_lines[-2].strip() == "":
-        # Reduce multiple trailing blanks to a single one
-        while len(new_lines) >= 2 and new_lines[-1].strip() == "" and new_lines[-2].strip() == "":
-            new_lines.pop()
+    while len(new_lines) >= 2 and not new_lines[-1].strip() and not new_lines[-2].strip():
+        new_lines.pop()
 
-    # Append the new project section
     new_lines.append(f"[{project_name}]\n")
     new_lines.append(f"PROJECT_NAME = {project_name_value}\n")
 
-    # Write back preserving all original comments and formatting elsewhere
+    board_dir = ini_file.parent
     try:
-        # Ensure board directory and file are writable
-        board_dirname = os.path.dirname(ini_file)
-        if board_dirname and not os.access(board_dirname, os.W_OK):
-            log.error("Board directory is not writable: '%s'", board_dirname)
-            print(f"Error: Board directory is not writable: '{board_dirname}'")
+        if board_dir and not _safe_access(board_dir, os.W_OK):
+            log.error("Board directory is not writable: '%s'", board_dir)
+            print(f"Error: Board directory is not writable: '{board_dir}'")
             return False
-        if not os.access(ini_file, os.W_OK):
+        if not _safe_access(ini_file, os.W_OK):
             log.error("INI file is not writable: '%s'", ini_file)
             print(f"Error: INI file is not writable: '{ini_file}'")
             return False
-        with open(ini_file, "w", encoding="utf-8") as f:
-            f.writelines(new_lines)
+        ini_file.write_text("".join(new_lines), encoding="utf-8")
     except (PermissionError, OSError, UnicodeError) as err:
         log.error("Failed to write INI file '%s': %s", ini_file, err)
         print(f"Error: Failed to write INI file '{ini_file}': {err}")
@@ -205,55 +220,50 @@ def project_new(env: Dict, projects_info: Dict, project_name: str) -> bool:
     log.debug("Created new project '%s' in board '%s'.", project_name, board_name)
     print(f"Created new project '{project_name}' in board '{board_name}'.")
 
-    # Print all config for the new project (merged: ini section + inherited config['config'])
-    # Re-read using ConfigUpdater to fetch the new section values
     config_after = ConfigUpdater()
     config_after.optionxform = str
     try:
-        config_after.read(ini_file, encoding="utf-8")
+        config_after.read(str(ini_file), encoding="utf-8")
     except (PermissionError, OSError, UnicodeError) as err:
         log.error("Failed to re-read INI file '%s': %s", ini_file, err)
         print(f"Error: Failed to re-read INI file '{ini_file}': {err}")
         return False
-    parent_config = inherited_config.get("config", {}) if isinstance(inherited_config.get("config", {}), dict) else {}
+
     merged_config = dict(parent_config)
     if project_name in config_after:
         for key, value in config_after[project_name].items():
             merged_config[key] = value.value if hasattr(value, "value") else value
+
     print(f"All config for project '{project_name}':")
     for key, value in merged_config.items():
         print(f"  {key} = {value}")
+
+    project_dir = board_path / project_name
+    project_dir.mkdir(parents=True, exist_ok=True)
+    log.info("Project '%s' created in board '%s'.", project_name, board_name)
+    print(f"Project '{project_name}' created in board '{board_name}'.")
     return True
 
 
 @register("project_del", needs_repositories=False, desc="Delete the specified project.")
 def project_del(env: Dict, projects_info: Dict, project_name: str) -> bool:
-    """
-    Delete the specified project directory and update its status in the config file.
-    Args:
-        env (dict): Global environment dict.
-        projects_info (dict): All projects info.
-        project_name (str): Project name.
-    """
+    """Delete the specified project and any nested subprojects."""
 
     _ = env
 
-    def find_all_subprojects(projects_info, project_name):
-        """Find all subprojects recursively whose names start with project_name-"""
-        subprojects = []
-        for name in projects_info:
-            if name != project_name and name.startswith(project_name + "-"):
-                subprojects.append(name)
-        all_subs = []
-        for sub in subprojects:
-            all_subs.append(sub)
-            all_subs.extend(find_all_subprojects(projects_info, sub))
-        return all_subs
+    def find_all_subprojects(name: str) -> List[str]:
+        direct = [candidate for candidate in projects_info if candidate != name and candidate.startswith(f"{name}-")]
+        descendants: List[str] = []
+        for child in direct:
+            descendants.append(child)
+            descendants.extend(find_all_subprojects(child))
+        return descendants
 
     project_cfg = projects_info.get(project_name, {})
     board_name = project_cfg.get("board_name")
-    board_path = project_cfg.get("board_path")
-    ini_file = project_cfg.get("ini_file")
+    board_path = Path(project_cfg.get("board_path", "")) if project_cfg.get("board_path") else None
+    ini_file = Path(project_cfg.get("ini_file", "")) if project_cfg.get("ini_file") else None
+
     if not project_name:
         log.error("Project name must be provided.")
         print("Error: Project name must be provided.")
@@ -262,20 +272,14 @@ def project_del(env: Dict, projects_info: Dict, project_name: str) -> bool:
         log.error("Board info missing for project '%s'", project_name)
         print(f"Error: Board info missing for project '{project_name}'.")
         return False
-    if not os.path.isdir(board_path):
-        log.error(
-            "Board directory '%s' does not exist for project '%s'.",
-            board_name,
-            project_name,
-        )
+    if not board_path.is_dir():
+        log.error("Board directory '%s' does not exist for project '%s'.", board_name, project_name)
         print(f"Error: Board directory '{board_name}' does not exist for project '{project_name}'.")
         return False
-    if not ini_file:
+    if not ini_file or not ini_file.exists():
         log.error("No ini file found for board: '%s'", board_name)
         print(f"No ini file found for board: '{board_name}'")
         return False
-
-    # project_name cannot be the same as board_name
     if project_name == board_name:
         log.error("Project name '%s' cannot be the same as board name.", project_name)
         print(f"Error: Project name '{project_name}' cannot be the same as board name.")
@@ -283,199 +287,146 @@ def project_del(env: Dict, projects_info: Dict, project_name: str) -> bool:
 
     config = ConfigUpdater()
     config.optionxform = str
-    config.read(ini_file, encoding="utf-8")
-    # Recursively delete all subprojects
-    to_delete = [project_name] + find_all_subprojects(projects_info, project_name)
-    for del_name in to_delete:
-        if del_name not in config.sections():
-            log.info("Project '%s' does not exist in board '%s'.", del_name, board_name)
-            print(f"Project '{del_name}' does not exist in board '{board_name}'.")
+    config.read(str(ini_file), encoding="utf-8")
+    to_delete = [project_name] + find_all_subprojects(project_name)
+    for name in to_delete:
+        if name not in config.sections():
+            log.info("Project '%s' does not exist in board '%s'.", name, board_name)
+            print(f"Project '{name}' does not exist in board '{board_name}'.")
         else:
-            config.remove_section(del_name)
-            log.debug("Removed project '%s' from board '%s'.", del_name, board_name)
-            print(f"Removed project '{del_name}' from board '{board_name}'.")
+            config.remove_section(name)
+            log.debug("Removed project '%s' from board '%s'.", name, board_name)
+            print(f"Removed project '{name}' from board '{board_name}'.")
     config.update_file()
     return True
 
 
 @register("board_new", needs_repositories=False, desc="Create a new board.")
 def board_new(env: Dict, projects_info: Dict, board_name: str) -> bool:
-    """
-    Create a new board.
-    Args:
-        env (dict): Global environment dict.
-        projects_info (dict): All projects info.
-        board_name (str): Board name.
-    """
+    """Create a new board and scaffold its directory structure."""
 
     _ = projects_info
 
-    if not isinstance(board_name, str) or not board_name.strip():
-        log.error("Board name must be a non-empty string.")
-        print("Error: Board name must be a non-empty string.")
+    normalised = _normalise_board_name(board_name)
+    if not normalised:
+        log.error("Board name must be a non-empty relative path without special components.")
+        print("Error: Board name must be a non-empty relative path without special components.")
         return False
-
-    board_name = board_name.strip()
-    if board_name in {".", ".."}:
-        log.error("Board name '%s' is not allowed.", board_name)
-        print(f"Error: Board name '{board_name}' is not allowed.")
-        return False
-
-    normalised_board_name = os.path.normpath(board_name)
-    if normalised_board_name in {".", ".."}:
-        log.error("Board name '%s' resolves to an invalid path.", board_name)
-        print(f"Error: Board name '{board_name}' resolves to an invalid path.")
-        return False
-
-    if os.path.isabs(normalised_board_name):
-        log.error("Board name '%s' must not resolve to an absolute path.", board_name)
-        print(f"Error: Board name '{board_name}' must not resolve to an absolute path.")
-        return False
-
-    if any(sep in board_name for sep in (os.sep, os.altsep) if sep):
-        log.error("Board name '%s' contains invalid path characters.", board_name)
-        print(f"Error: Board name '{board_name}' contains invalid path characters.")
-        return False
-
-    board_name = normalised_board_name
-
-    reserved_names = {"common", "template", "scripts", ".cache", ".git"}
-    if board_name in reserved_names:
-        log.error("Board name '%s' is reserved and cannot be used.", board_name)
-        print(f"Error: Board name '{board_name}' is reserved and cannot be used.")
+    if _reserved_board_name(normalised):
+        log.error("Board name '%s' is reserved and cannot be used.", normalised)
+        print(f"Error: Board name '{normalised}' is reserved and cannot be used.")
         return False
 
     if not isinstance(env, dict):
         log.error("Environment must be a dictionary containing 'projects_path'.")
         print("Error: Environment must contain 'projects_path'.")
         return False
-
     projects_path = env.get("projects_path")
     if not isinstance(projects_path, str) or not projects_path.strip():
         log.error("Invalid 'projects_path' in environment: %s", projects_path)
         print("Error: Invalid 'projects_path' in environment.")
         return False
 
-    projects_path = os.path.abspath(projects_path)
+    projects_root = Path(projects_path).resolve()
     try:
-        os.makedirs(projects_path, exist_ok=True)
+        projects_root.mkdir(parents=True, exist_ok=True)
     except OSError as err:
-        log.error("Failed to ensure projects path '%s': %s", projects_path, err)
-        print(f"Error: Failed to ensure projects path '{projects_path}': {err}")
+        log.error("Failed to ensure projects path '%s': %s", projects_root, err)
+        print(f"Error: Failed to ensure projects path '{projects_root}': {err}")
         return False
 
-    board_path = os.path.abspath(os.path.join(projects_path, board_name))
-    if os.path.commonpath([projects_path, board_path]) != projects_path:
-        log.error(
-            "Board name '%s' resolves outside of projects path '%s'.",
-            board_name,
-            projects_path,
-        )
-        print(
-            f"Error: Board name '{board_name}' resolves outside of projects path '{projects_path}'."
-        )
+    board_path = (projects_root / normalised).resolve()
+    try:
+        board_path.relative_to(projects_root)
+    except ValueError:
+        log.error("Board name '%s' resolves outside of projects path '%s'.", normalised, projects_root)
+        print(f"Error: Board name '{normalised}' resolves outside of projects path '{projects_root}'.")
         return False
-    if os.path.exists(board_path):
-        log.error("Board '%s' already exists at '%s'.", board_name, board_path)
-        print(f"Error: Board '{board_name}' already exists.")
+    if board_path.exists():
+        log.error("Board '%s' already exists at '%s'.", normalised, board_path)
+        print(f"Error: Board '{normalised}' already exists.")
         return False
 
-    po_path = os.path.join(board_path, "po")
-    ini_path = os.path.join(board_path, f"{board_name}.ini")
-    projects_json_path = os.path.join(board_path, "projects.json")
+    po_path = board_path / "po"
+    ini_path = board_path / f"{normalised}.ini"
+    projects_json_path = board_path / "projects.json"
 
-    template_dir = os.path.join(projects_path, "template")
-    template_ini_path = os.path.join(template_dir, "template.ini")
-    template_po_path = os.path.join(template_dir, "po")
+    template_dir = projects_root / "template"
+    template_ini_path = template_dir / "template.ini"
+    template_po_path = template_dir / "po"
 
     def _generate_ini_lines() -> List[str]:
         default_lines = [
-            f"[{board_name}]\n",
+            f"[{normalised}]\n",
             "PROJECT_NAME = \n",
             "PROJECT_VERSION = \n",
             "PROJECT_PO_CONFIG = \n",
             "PROJECT_PO_IGNORE = \n",
         ]
-        if not os.path.isfile(template_ini_path):
+        if not template_ini_path.is_file():
             return default_lines
         try:
-            with open(template_ini_path, "r", encoding="utf-8") as template_file:
-                lines = template_file.readlines()
+            lines = template_ini_path.read_text(encoding="utf-8").splitlines(keepends=True)
         except (OSError, UnicodeError) as err:
-            log.warning(
-                "Failed to read template ini '%s': %s. Using default template.",
-                template_ini_path,
-                err,
-            )
+            log.warning("Failed to read template ini '%s': %s. Using default template.", template_ini_path, err)
             return default_lines
-
         replaced = False
-        ini_lines = []
+        ini_lines: List[str] = []
         for line in lines:
             stripped = line.strip()
             if not replaced and stripped.startswith("[") and stripped.endswith("]"):
-                ini_lines.append(f"[{board_name}]\n")
+                ini_lines.append(f"[{normalised}]\n")
                 replaced = True
             else:
                 ini_lines.append(line)
         if not ini_lines:
             return default_lines
         if not replaced:
-            ini_lines.insert(0, f"[{board_name}]\n")
+            ini_lines.insert(0, f"[{normalised}]\n")
         return ini_lines
 
     def _initialise_po_directory() -> None:
-        if os.path.isdir(template_po_path):
+        if template_po_path.is_dir():
             try:
                 shutil.copytree(template_po_path, po_path)
+                return
             except FileExistsError:
-                # Destination should be empty for new boards, but fall back to
-                # copying contents to support environments that may create the
-                # directory earlier (e.g. via concurrent setup steps).
-                for root, _dirs, files in os.walk(template_po_path):
-                    rel_root = os.path.relpath(root, template_po_path)
-                    dest_root = po_path if rel_root == "." else os.path.join(po_path, rel_root)
-                    os.makedirs(dest_root, exist_ok=True)
-                    for file_name in files:
-                        shutil.copy2(
-                            os.path.join(root, file_name),
-                            os.path.join(dest_root, file_name),
-                        )
+                pass
+            for root, _dirs, files in os.walk(template_po_path):
+                rel_root = Path(root).relative_to(template_po_path)
+                dest_root = po_path if rel_root == Path(".") else po_path / rel_root
+                dest_root.mkdir(parents=True, exist_ok=True)
+                for file_name in files:
+                    shutil.copy2(Path(root) / file_name, dest_root / file_name)
             return
-
-        os.makedirs(po_path, exist_ok=False)
-        default_po_root = os.path.join(po_path, "po_template")
+        default_po_root = po_path / "po_template"
         for subdir in ("patches", "overrides"):
-            os.makedirs(os.path.join(default_po_root, subdir), exist_ok=True)
+            (default_po_root / subdir).mkdir(parents=True, exist_ok=True)
 
     try:
-        os.makedirs(board_path, exist_ok=False)
+        board_path.mkdir(parents=False, exist_ok=False)
         _initialise_po_directory()
-        ini_lines = _generate_ini_lines()
-        with open(ini_path, "w", encoding="utf-8") as ini_file:
-            ini_file.writelines(ini_lines)
-
+        ini_path.write_text("".join(_generate_ini_lines()), encoding="utf-8")
         board_metadata = {
-            "board_name": board_name,
-            "board_path": board_path,
+            "board_name": normalised,
+            "board_path": str(board_path),
             "last_updated": datetime.now().isoformat(),
             "projects": [],
         }
-        with open(projects_json_path, "w", encoding="utf-8") as json_file:
-            json.dump(board_metadata, json_file, indent=2, ensure_ascii=False)
+        projects_json_path.write_text(json.dumps(board_metadata, indent=2, ensure_ascii=False), encoding="utf-8")
     except FileExistsError:
-        log.error("Board directory structure for '%s' already exists.", board_name)
-        print(f"Error: Board '{board_name}' already exists.")
+        log.error("Board directory structure for '%s' already exists.", normalised)
+        print(f"Error: Board '{normalised}' already exists.")
         return False
     except (OSError, UnicodeError, ValueError) as err:
-        log.error("Failed to create board '%s': %s", board_name, err)
-        print(f"Error: Failed to create board '{board_name}': {err}")
-        if os.path.isdir(board_path):
+        log.error("Failed to create board '%s': %s", normalised, err)
+        print(f"Error: Failed to create board '{normalised}': {err}")
+        if board_path.is_dir():
             shutil.rmtree(board_path, ignore_errors=True)
         return False
 
-    log.debug("Created new board '%s' at '%s'.", board_name, board_path)
-    print(f"Created new board '{board_name}' at '{board_path}'.")
+    log.debug("Created new board '%s' at '%s'.", normalised, board_path)
+    print(f"Created new board '{normalised}' at '{board_path}'.")
     print(f"Board ini file: {ini_path}")
     print(f"PO directory: {po_path}")
     return True
@@ -483,178 +434,124 @@ def board_new(env: Dict, projects_info: Dict, board_name: str) -> bool:
 
 @register("board_del", needs_repositories=False, desc="Delete the specified board.")
 def board_del(env: Dict, projects_info: Dict, board_name: str) -> bool:
-    """
-    Delete the specified board.
-    Args:
-        env (dict): Global environment dict.
-        projects_info (dict): All projects info.
-        board_name (str): Board name.
-    """
-    if not isinstance(board_name, str) or not board_name.strip():
-        log.error("Board name must be a non-empty string.")
-        print("Error: Board name must be a non-empty string.")
+    """Delete a board and clean up associated cache entries."""
+
+    normalised = _normalise_board_name(board_name)
+    if not normalised:
+        log.error("Board name must be a non-empty relative path without special components.")
+        print("Error: Board name must be a non-empty relative path without special components.")
+        return False
+    if _reserved_board_name(normalised):
+        log.error("Board name '%s' is reserved and cannot be used.", normalised)
+        print(f"Error: Board name '{normalised}' is reserved and cannot be used.")
         return False
 
-    board_name = board_name.strip()
-    if board_name in {".", ".."}:
-        log.error("Board name '%s' is not allowed.", board_name)
-        print(f"Error: Board name '{board_name}' is not allowed.")
-        return False
-
-    normalised_board_name = os.path.normpath(board_name)
-    if normalised_board_name in {".", ".."}:
-        log.error("Board name '%s' resolves to an invalid path.", board_name)
-        print(f"Error: Board name '{board_name}' resolves to an invalid path.")
-        return False
-
-    if os.path.isabs(normalised_board_name):
-        log.error("Board name '%s' must not resolve to an absolute path.", board_name)
-        print(f"Error: Board name '{board_name}' must not resolve to an absolute path.")
-        return False
-
-    if any(sep in board_name for sep in (os.sep, os.altsep) if sep):
-        log.error("Board name '%s' contains invalid path characters.", board_name)
-        print(f"Error: Board name '{board_name}' contains invalid path characters.")
-        return False
-
-    board_name = normalised_board_name
-
-    reserved_names = {"common", "template", "scripts", ".cache", ".git"}
-    if board_name in reserved_names:
-        log.error("Board '%s' is reserved and cannot be deleted.", board_name)
-        print(f"Error: Board '{board_name}' is reserved and cannot be deleted.")
-        return False
-
-    if not isinstance(env, dict):
-        log.error("Environment must be a dictionary containing 'projects_path'.")
-        print("Error: Environment must contain 'projects_path'.")
-        return False
-
-    projects_path = env.get("projects_path")
+    projects_path = env.get("projects_path") if isinstance(env, dict) else None
     if not isinstance(projects_path, str) or not projects_path.strip():
         log.error("Invalid 'projects_path' in environment: %s", projects_path)
         print("Error: Invalid 'projects_path' in environment.")
         return False
 
-    protected_boards = env.get("protected_boards", [])
-    if isinstance(protected_boards, (set, list, tuple)) and board_name in set(protected_boards):
-        log.error("Board '%s' is protected and cannot be deleted.", board_name)
-        print(f"Error: Board '{board_name}' is protected and cannot be deleted.")
+    protected_boards = env.get("protected_boards", []) if isinstance(env, dict) else []
+    if isinstance(protected_boards, (set, list, tuple)) and normalised in set(protected_boards):
+        log.error("Board '%s' is protected and cannot be deleted.", normalised)
+        print(f"Error: Board '{normalised}' is protected and cannot be deleted.")
         return False
 
-    projects_path = os.path.abspath(projects_path)
-    board_path = os.path.abspath(os.path.join(projects_path, board_name))
-    if os.path.commonpath([projects_path, board_path]) != projects_path:
-        log.error(
-            "Board name '%s' resolves outside of projects path '%s'.",
-            board_name,
-            projects_path,
-        )
-        print(
-            f"Error: Board name '{board_name}' resolves outside of projects path '{projects_path}'."
-        )
+    projects_root = Path(projects_path).resolve()
+    board_path = (projects_root / normalised).resolve()
+    try:
+        board_path.relative_to(projects_root)
+    except ValueError:
+        log.error("Board name '%s' resolves outside of projects path '%s'.", normalised, projects_root)
+        print(f"Error: Board name '{normalised}' resolves outside of projects path '{projects_root}'.")
         return False
-    if not os.path.isdir(board_path):
-        log.error("Board '%s' does not exist at '%s'.", board_name, board_path)
-        print(f"Error: Board '{board_name}' does not exist.")
+    if not board_path.is_dir():
+        log.error("Board '%s' does not exist at '%s'.", normalised, board_path)
+        print(f"Error: Board '{normalised}' does not exist.")
         return False
 
-    log.debug("Deleting board '%s' at '%s'.", board_name, board_path)
-
+    log.debug("Deleting board '%s' at '%s'.", normalised, board_path)
     try:
         shutil.rmtree(board_path)
     except OSError as err:
-        log.error("Failed to delete board '%s': %s", board_name, err)
-        print(f"Error: Failed to delete board '{board_name}': {err}")
+        log.error("Failed to delete board '%s': %s", normalised, err)
+        print(f"Error: Failed to delete board '{normalised}': {err}")
         return False
 
-    root_path = env.get("root_path")
+    root_path = env.get("root_path") if isinstance(env, dict) else None
     if not isinstance(root_path, str) or not root_path:
-        root_path = os.path.abspath(os.path.join(projects_path, os.pardir))
+        root_path = projects_root.parent
 
     cache_paths = [
-        os.path.join(root_path, ".cache", "projects", board_name),
-        os.path.join(root_path, ".cache", "boards", board_name),
-        os.path.join(root_path, ".cache", "build", board_name),
+        Path(root_path) / ".cache" / "projects" / normalised,
+        Path(root_path) / ".cache" / "boards" / normalised,
+        Path(root_path) / ".cache" / "build" / normalised,
     ]
     for cache_path in cache_paths:
-        if os.path.exists(cache_path):
+        if cache_path.exists():
             try:
                 shutil.rmtree(cache_path)
                 log.debug("Removed cache directory '%s'.", cache_path)
             except OSError as err:
                 log.warning("Failed to remove cache path '%s': %s", cache_path, err)
 
-    def _update_projects_index(projects_path: str, board: str) -> None:
-        index_path = os.path.join(projects_path, "projects.json")
-        if not os.path.isfile(index_path):
+    def _update_projects_index(projects_dir: Path, board: str) -> None:
+        index_path = projects_dir / "projects.json"
+        if not index_path.is_file():
             return
-
         try:
-            with open(index_path, "r", encoding="utf-8") as index_file:
-                data = json.load(index_file)
+            payload = json.loads(index_path.read_text(encoding="utf-8"))
         except (OSError, UnicodeError, json.JSONDecodeError) as err:
             log.warning("Failed to read projects index '%s': %s", index_path, err)
             return
-
         changed = False
-        payload = data
-        if isinstance(data, dict):
-            if board in data:
-                data.pop(board, None)
+        updated = payload
+        if isinstance(payload, dict):
+            if board in payload:
+                payload.pop(board, None)
                 changed = True
-            elif "boards" in data and isinstance(data["boards"], dict):
-                if board in data["boards"]:
-                    data["boards"].pop(board, None)
+            elif isinstance(payload.get("boards"), dict) and board in payload["boards"]:
+                payload["boards"].pop(board, None)
+                changed = True
+            elif isinstance(payload.get("boards"), list):
+                filtered = [item for item in payload["boards"] if item != board]
+                if len(filtered) != len(payload["boards"]):
+                    payload["boards"] = filtered
                     changed = True
-            elif "boards" in data and isinstance(data["boards"], list):
-                filtered_boards = [item for item in data["boards"] if item != board]
-                if len(filtered_boards) != len(data["boards"]):
-                    data["boards"] = filtered_boards
-                    changed = True
-        elif isinstance(data, list):
-            filtered_data = [item for item in data if item != board]
-            if len(filtered_data) != len(data):
-                payload = filtered_data
+        elif isinstance(payload, list):
+            filtered = [item for item in payload if item != board]
+            if len(filtered) != len(payload):
+                updated = filtered
                 changed = True
         else:
-            log.debug(
-                "Projects index '%s' has unsupported format (%s). Skipping update.",
-                index_path,
-                type(data),
-            )
+            log.debug("Projects index '%s' has unsupported format (%s). Skipping update.", index_path, type(payload))
             return
-
         if changed:
             try:
-                with open(index_path, "w", encoding="utf-8") as index_file:
-                    json.dump(payload, index_file, indent=2, ensure_ascii=False)
-                log.debug(
-                    "Updated projects index '%s' after deleting board '%s'.",
-                    index_path,
-                    board,
-                )
+                index_path.write_text(json.dumps(updated, indent=2, ensure_ascii=False), encoding="utf-8")
+                log.debug("Updated projects index '%s' after deleting board '%s'.", index_path, board)
             except (OSError, UnicodeError, ValueError) as err:
                 log.warning("Failed to update projects index '%s': %s", index_path, err)
 
-    _update_projects_index(projects_path, board_name)
+    _update_projects_index(projects_root, normalised)
 
     if isinstance(projects_info, dict):
-        removed_projects = [
+        removed = [
             name
             for name, info in list(projects_info.items())
-            if isinstance(info, dict) and info.get("board_name") == board_name
+            if isinstance(info, dict) and info.get("board_name") == normalised
         ]
-        for name in removed_projects:
+        for name in removed:
             projects_info.pop(name, None)
-        if board_name in projects_info:
-            projects_info.pop(board_name, None)
-        if removed_projects:
+        if normalised in projects_info:
+            projects_info.pop(normalised, None)
+        if removed:
             log.debug(
                 "Removed %d project(s) associated with board '%s' from in-memory index.",
-                len(removed_projects),
-                board_name,
+                len(removed),
+                normalised,
             )
 
-    print(f"Deleted board '{board_name}'.")
+    print(f"Deleted board '{normalised}'.")
     return True

--- a/src/profiler.py
+++ b/src/profiler.py
@@ -1,6 +1,6 @@
-"""
-Profiling decorators for performance analysis.
-"""
+"""Runtime profiling helpers used by the CLI entry points."""
+
+from __future__ import annotations
 
 import builtins
 import cProfile
@@ -8,68 +8,81 @@ import io
 import pstats
 import time
 from functools import wraps
+from pathlib import Path
+from typing import Any, Callable, TypeVar, cast
 
 from src.log_manager import log
 from src.utils import path_from_root
 
-CPROFILE_PATH = path_from_root(".cache", "cprofile")
+CPROFILE_PATH = Path(path_from_root(".cache", "cprofile"))
 PROFILE_DUMP_NAME = "profile_dump"
 
+F = TypeVar("F", bound=Callable[..., Any])
 
-def func_time(func):
+
+def func_time(func: F) -> F:
     """Decorator to measure function execution time."""
 
     @wraps(func)
-    def wrapper(*args, **kwargs):
-        start = time.time()
-        result = func(*args, **kwargs)
-        end = time.time()
-        log.debug("%s took %f seconds", func.__name__, end - start)
-        return result
+    def wrapper(*args: Any, **kwargs: Any):
+        start = time.perf_counter()
+        try:
+            return func(*args, **kwargs)
+        finally:
+            duration = time.perf_counter() - start
+            log.debug("%s took %f seconds", func.__name__, duration)
 
-    return wrapper
+    return cast(F, wrapper)
 
 
-def func_cprofile(func):
+def func_cprofile(func: F) -> F:
     """Decorator to profile a function using cProfile and log stats."""
 
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any):
         enable_cprofile = getattr(builtins, "ENABLE_CPROFILE", False)
         if enable_cprofile:
             profile = cProfile.Profile()
+            profile.enable()
             try:
-                profile.enable()
                 result = func(*args, **kwargs)
-                profile.disable()
-                return result
             finally:
+                profile.disable()
                 try:
+                    CPROFILE_PATH.mkdir(parents=True, exist_ok=True)
                     s = io.StringIO()
-                    ps = pstats.Stats(profile, stream=s)
-                    ps.sort_stats("time").print_stats()  # print all
+                    stats = pstats.Stats(profile, stream=s)
+                    stats.sort_stats("time").print_stats()
                     log.debug("cProfile stats for %s:\n%s", func.__name__, s.getvalue())
+                    timestamp = time.strftime("%Y%m%d_%H%M%S")
+                    dump_path = CPROFILE_PATH / f"{PROFILE_DUMP_NAME}_{func.__name__}_{timestamp}.prof"
+                    profile.dump_stats(dump_path)
+                    log.debug("cProfile dump written to %s", dump_path)
                 except (OSError, IOError) as exc:
                     log.exception("fail to print cProfile stats: %s", exc)
-        else:
-            return func(*args, **kwargs)
+            return result
+        return func(*args, **kwargs)
 
-    return wrapper
+    return cast(F, wrapper)
 
 
-def auto_profile(cls):
+def auto_profile(cls: type) -> type:
+    """Decorate public instance methods with timing and optional profiling wrappers.
+
+    The decorator preserves ``staticmethod`` and ``classmethod`` descriptors so that method
+    bindings remain intact.
     """
-    Class decorator: automatically decorate all public instance methods with func_time and (optionally) func_cprofile, dynamically at call time.
-    Ensures that staticmethod/classmethod wrapper types are not lost.
-    """
 
-    def make_wrapper(func):
+    def make_wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
+        timed = func_time(func)
+        profiled = func_time(func_cprofile(func))
+
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any):
             enable_cprofile = getattr(builtins, "ENABLE_CPROFILE", False)
             if enable_cprofile:
-                return func_time(func_cprofile(func))(*args, **kwargs)
-            return func_time(func)(*args, **kwargs)
+                return profiled(*args, **kwargs)
+            return timed(*args, **kwargs)
 
         return wrapper
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,115 @@
+"""Behavioural tests for the hook registration and execution helpers."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Dict, List
+
+import pytest
+
+# Ensure the project source directory is importable when tests run in isolation.
+# pylint: disable=wrong-import-position
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.hooks import (
+    HookPriority,
+    HookType,
+    clear_hooks,
+    execute_hooks,
+    register_hook,
+    validate_hooks,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_hooks_between_tests() -> None:
+    """Ensure each test runs with an empty registry."""
+
+    clear_hooks()
+
+
+def test_execute_hook_binds_context_and_named_arguments() -> None:
+    """Positional parameters beyond the context are populated from the context dict."""
+
+    calls: List[Dict[str, Any]] = []
+
+    def sample_hook(ctx: Dict[str, Any], board_name: str) -> bool:
+        calls.append({"board": board_name, "value": ctx["value"]})
+        return True
+
+    register_hook(HookType.CUSTOM, "sample", sample_hook, priority=HookPriority.NORMAL)
+
+    context = {"value": 7, "board_name": "demo"}
+    assert execute_hooks(HookType.CUSTOM, context)
+    assert calls == [{"board": "demo", "value": 7}]
+
+
+def test_execute_hook_supports_keyword_only_context() -> None:
+    """Hooks declaring a keyword-only context parameter receive it correctly."""
+
+    captured: List[int] = []
+
+    def keyword_only_hook(*, context: Dict[str, int]) -> None:
+        captured.append(context["value"])
+
+    register_hook(HookType.CUSTOM, "keyword_only", keyword_only_hook)
+
+    assert execute_hooks(HookType.CUSTOM, {"value": 3})
+    assert captured == [3]
+
+
+def test_execute_hook_supports_kwargs_only_function() -> None:
+    """Hooks with only ``**kwargs`` receive the full context mapping."""
+
+    captured: List[Dict[str, Any]] = []
+
+    def kwargs_only_hook(**kwargs: Any) -> None:
+        captured.append(kwargs)
+
+    register_hook(HookType.CUSTOM, "kwargs_only", kwargs_only_hook)
+
+    context = {"value": 5, "extra": "info"}
+    assert execute_hooks(HookType.CUSTOM, context)
+    assert captured == [context]
+
+
+def test_execute_hook_supports_varargs_context() -> None:
+    """Hooks that rely on ``*args`` still receive the context dictionary."""
+
+    captured: List[int] = []
+
+    def varargs_hook(*args: Any) -> None:
+        assert args
+        captured.append(args[0]["value"])
+
+    register_hook(HookType.CUSTOM, "varargs", varargs_hook)
+
+    assert execute_hooks(HookType.CUSTOM, {"value": 11})
+    assert captured == [11]
+
+
+def test_execute_hook_missing_required_argument_reports_failure() -> None:
+    """A missing required parameter surfaces as an execution failure."""
+
+    def requires_missing(context: Dict[str, Any], required: int) -> None:  # pragma: no cover - exercised via hooks
+        raise AssertionError("Should not be reached")
+
+    register_hook(HookType.CUSTOM, "requires_missing", requires_missing)
+
+    assert not execute_hooks(HookType.CUSTOM, {"value": 9}, stop_on_error=True)
+
+
+def test_validate_hooks_flags_no_argument_hook() -> None:
+    """Hooks without parameters are highlighted by validation."""
+
+    def no_args_hook() -> None:  # pragma: no cover - invoked through validation metadata
+        raise AssertionError("Should not be invoked")
+
+    register_hook(HookType.CUSTOM, "no_args", no_args_hook)
+
+    validation = validate_hooks(HookType.CUSTOM)
+    assert not validation["valid"]
+    assert validation["invalid_hooks"] == [
+        {"name": "no_args", "error": "Function must accept at least one parameter"}
+    ]


### PR DESCRIPTION
## Summary
- replace ad-hoc project discovery with a `ProjectRecord` dataclass, pathlib-based IO, and explicit JSON persistence helpers in `__main__`
- store operation metadata in a typed registry so command-line helpers can rely on structured descriptors instead of ad-hoc attributes
- rework project builder and manager plugins to use pathlib, typed contexts, and clearer validation when scaffolding or cleaning boards
- add lightweight annotations to patch/override utilities and package init to improve typing coverage

## Testing
- pytest
- pylint src tests

------
https://chatgpt.com/codex/tasks/task_e_68db8133b0d88324ab6f0239db200079