### PR TITLE
fix: verify sha256 for upgrade

### DIFF
--- a/docs/en/user-guide/command-reference.md
+++ b/docs/en/user-guide/command-reference.md
@@ -30,16 +30,17 @@ All commands accept the following global options:
 
 **Syntax**
 ```bash
-python -m src upgrade [--user|--system|--prefix <dir>] [--owner <owner>] [--repo <repo>]
+python -m src upgrade [--user|--system|--prefix <dir>] [--owner <owner>] [--repo <repo>] [--require-checksum]
 ```
 
-**Description**: Auto-detect the current platform/architecture, fetch the latest GitHub Release asset, and install `projman` to the selected location.
+**Description**: Auto-detect the current platform/architecture, fetch the latest GitHub Release asset, optionally verify sha256 checksum (if published), and install `projman` to the selected location.
 
 **Examples**
 ```bash
 python -m src upgrade --user
 python -m src upgrade --prefix ~/.local/bin
 python -m src upgrade --dry-run
+python -m src upgrade --require-checksum
 ```
 
 ---

--- a/tests/whitebox/plugins/test_upgrader.py
+++ b/tests/whitebox/plugins/test_upgrader.py
@@ -1,5 +1,6 @@
 """Tests for src.plugins.upgrader."""
 
+import hashlib
 import os
 import sys
 from unittest.mock import patch
@@ -86,6 +87,130 @@ class TestUpgrader:
         target = install_dir / "projman"
         assert target.exists()
         assert target.read_bytes() == b"projman-binary"
+
+    def test_upgrade_verifies_sha256_when_available(self, tmp_path):
+        install_dir = tmp_path / "install-bin"
+        downloaded = tmp_path / "downloaded-projman"
+        payload = b"projman-binary"
+        downloaded.write_bytes(payload)
+
+        checksum = hashlib.sha256(payload).hexdigest()
+        checksum_file = tmp_path / "downloaded-projman.sha256"
+        checksum_file.write_text(f"{checksum}  projman-linux-x86_64\n", encoding="utf-8")
+
+        release_data = {
+            "tag_name": "v0.0.12",
+            "assets": [
+                {
+                    "name": "projman-linux-x86_64",
+                    "browser_download_url": "https://example.com/projman-linux-x86_64",
+                },
+                {
+                    "name": "projman-linux-x86_64.sha256",
+                    "browser_download_url": "https://example.com/projman-linux-x86_64.sha256",
+                },
+            ],
+        }
+
+        def download_side_effect(url: str, _token: str) -> str:
+            if url.endswith(".sha256"):
+                return str(checksum_file)
+            return str(downloaded)
+
+        with (
+            patch.object(self.upgrader, "_normalize_platform_name", return_value="linux"),
+            patch.object(self.upgrader, "_normalize_arch", return_value="x86_64"),
+            patch.object(self.upgrader, "_is_admin_user", return_value=False),
+            patch.object(self.upgrader, "_http_get_json", return_value=release_data),
+            patch.object(self.upgrader, "_download_file", side_effect=download_side_effect),
+            patch.object(self.upgrader, "_verify_binary", return_value="0.0.12"),
+            patch.object(self.upgrader, "_path_contains", return_value=True),
+        ):
+            result = self.upgrader.upgrade(
+                env={},
+                projects_info={},
+                prefix=str(install_dir),
+            )
+
+        assert result is True
+        target = install_dir / "projman"
+        assert target.exists()
+        assert target.read_bytes() == payload
+
+    def test_upgrade_fails_on_sha256_mismatch(self, tmp_path):
+        install_dir = tmp_path / "install-bin"
+        downloaded = tmp_path / "downloaded-projman"
+        payload = b"projman-binary"
+        downloaded.write_bytes(payload)
+
+        checksum_file = tmp_path / "downloaded-projman.sha256"
+        checksum_file.write_text(f"{'0' * 64}  projman-linux-x86_64\n", encoding="utf-8")
+
+        release_data = {
+            "tag_name": "v0.0.12",
+            "assets": [
+                {
+                    "name": "projman-linux-x86_64",
+                    "browser_download_url": "https://example.com/projman-linux-x86_64",
+                },
+                {
+                    "name": "projman-linux-x86_64.sha256",
+                    "browser_download_url": "https://example.com/projman-linux-x86_64.sha256",
+                },
+            ],
+        }
+
+        def download_side_effect(url: str, _token: str) -> str:
+            if url.endswith(".sha256"):
+                return str(checksum_file)
+            return str(downloaded)
+
+        with (
+            patch.object(self.upgrader, "_normalize_platform_name", return_value="linux"),
+            patch.object(self.upgrader, "_normalize_arch", return_value="x86_64"),
+            patch.object(self.upgrader, "_is_admin_user", return_value=False),
+            patch.object(self.upgrader, "_http_get_json", return_value=release_data),
+            patch.object(self.upgrader, "_download_file", side_effect=download_side_effect),
+        ):
+            result = self.upgrader.upgrade(
+                env={},
+                projects_info={},
+                prefix=str(install_dir),
+            )
+
+        assert result is False
+        assert not (install_dir / "projman").exists()
+
+    def test_upgrade_requires_checksum_when_flag_set(self, tmp_path):
+        install_dir = tmp_path / "install-bin"
+        downloaded = tmp_path / "downloaded-projman"
+        downloaded.write_bytes(b"projman-binary")
+
+        release_data = {
+            "tag_name": "v0.0.12",
+            "assets": [
+                {
+                    "name": "projman-linux-x86_64",
+                    "browser_download_url": "https://example.com/projman-linux-x86_64",
+                }
+            ],
+        }
+
+        with (
+            patch.object(self.upgrader, "_normalize_platform_name", return_value="linux"),
+            patch.object(self.upgrader, "_normalize_arch", return_value="x86_64"),
+            patch.object(self.upgrader, "_is_admin_user", return_value=False),
+            patch.object(self.upgrader, "_http_get_json", return_value=release_data),
+            patch.object(self.upgrader, "_download_file", return_value=str(downloaded)),
+        ):
+            result = self.upgrader.upgrade(
+                env={},
+                projects_info={},
+                prefix=str(install_dir),
+                require_checksum=True,
+            )
+
+        assert result is False
 
     def test_upgrade_fails_when_matching_asset_missing(self):
         release_data = {


### PR DESCRIPTION
Fixes #7

Changes:
- Verify sha256 checksum when a matching `.sha256` release asset is available.
- Add `--require-checksum` to fail closed when checksum asset is missing.
- Add unit tests for checksum verify/mismatch/require-missing.
- Update docs for upgrade syntax.