### PR TITLE
fix: make platform script loading opt-in

### DIFF
--- a/docs/en/user-guide/command-reference.md
+++ b/docs/en/user-guide/command-reference.md
@@ -19,6 +19,7 @@ All commands accept the following global options:
 | `--version` | Print the current version | `python -m src --version` |
 | `--help` | Show help for the command or the CLI | `python -m src --help` |
 | `--perf-analyze` | Enable performance analysis logs | `python -m src --perf-analyze po_apply proj1` |
+| `--load-scripts` | Opt-in: import workspace scripts under `projects/scripts/*.py` (unsafe in untrusted workspaces) | `python -m src --load-scripts project_build proj1` |
 
 ---
 

--- a/docs/test_cases_en.md
+++ b/docs/test_cases_en.md
@@ -85,6 +85,8 @@
 | CLI-008 | CLI/Arg Parsing | Unsupported flag triggers TypeError | Dataset A completed | 1. Run `python -m src po_list projA --unknown-flag 1`. | TypeError occurs when calling the operation; process exits with error. | P1 | Negative |
 | CLI-009 | CLI/Arg Parsing | Missing required args show error | Dataset A completed | 1. Run `python -m src project_new`. | Error states missing required arguments and exits non-zero. | P0 | Negative |
 | CLI-010 | CLI/Arg Parsing | `upgrade --dry-run` works without projects dir | Run in an empty non-project workspace | 1. Run `python -m src upgrade --dry-run`.<br>2. Check stderr output. | Command exits 0 and does not print `common config not found` / `projects directory does not exist` warnings. | P1 | Functional |
+| CLI-013 | CLI/Security | Platform scripts are not auto-imported by default | Workspace has `projects/scripts/*.py` | 1. Create `projects/scripts/marker.py` that writes a marker file at import time.<br>2. Run `python -m src upgrade --dry-run`.<br>3. Check marker file does not exist. | Marker file is not created; scripts are not imported without explicit opt-in. | P0 | Security |
+| CLI-014 | CLI/Security | `--load-scripts` opts into platform script import | Workspace has `projects/scripts/*.py` | 1. Create `projects/scripts/marker.py` that writes a marker file at import time.<br>2. Run `python -m src --load-scripts upgrade --dry-run`.<br>3. Check marker file exists. | Marker file is created; scripts are imported only when explicitly enabled. | P0 | Security |
 
 ## 2. Config Loading & Project Index (src/__main__.py)
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -372,6 +372,26 @@ def _import_platform_scripts(projects_path):
     log.debug("Imported %d platform scripts from %s", imported_count, scripts_dir)
 
 
+def _env_truthy(value: str) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _should_load_platform_scripts(argv: List[str]) -> bool:
+    """
+    Decide whether to import projects/scripts/*.py.
+
+    Safety:
+    - Never auto-import by default.
+    - Never import for early-exit flags like --help / --version.
+    """
+
+    if "-h" in argv or "--help" in argv or "--version" in argv:
+        return False
+    if "--load-scripts" in argv:
+        return True
+    return _env_truthy(os.environ.get("PROJMAN_LOAD_SCRIPTS", ""))
+
+
 @func_time
 def _parse_args_and_plugin_args(builtin_operations):
     def _extract_plugin_tokens(argv: List[str], parsed_name: Optional[str]) -> List[str]:
@@ -501,6 +521,11 @@ def _parse_args_and_plugin_args(builtin_operations):
         "--perf-analyze",
         action="store_true",
         help="Enable cProfile performance analysis",
+    )
+    parser.add_argument(
+        "--load-scripts",
+        action="store_true",
+        help="Opt-in: import workspace scripts under projects/scripts/*.py (unsafe in untrusted workspaces).",
     )
 
     # Do not add plugin-related parameters to parser, only describe in epilog or help_text
@@ -880,8 +905,9 @@ def main():
         # "repositories": _find_repositories(),  # lazy loading
     }
 
-    # Import platform scripts
-    _import_platform_scripts(env["projects_path"])
+    # Opt-in: import platform scripts (workspace code execution).
+    if _should_load_platform_scripts(sys.argv[1:]):
+        _import_platform_scripts(env["projects_path"])
 
     builtin_operations = _load_builtin_plugin_operations()
     log.debug("Loaded %d builtin operations.", len(builtin_operations))

--- a/tests/blackbox/test_cli_security_blackbox_en.py
+++ b/tests/blackbox/test_cli_security_blackbox_en.py
@@ -1,0 +1,74 @@
+"""
+Black-box CLI security tests derived from docs/test_cases_en.md.
+
+Focus: ensure workspace scripts under projects/scripts are NOT auto-imported
+by default (opt-in only).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_cli(workdir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    # Ensure default behavior is tested deterministically.
+    env.pop("PROJMAN_LOAD_SCRIPTS", None)
+    return subprocess.run(
+        [sys.executable, "-m", "src", *args],
+        cwd=str(workdir),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_cli_platform_scripts_not_auto_imported_by_default(tmp_path: Path) -> None:
+    """CLI-013: platform scripts are not auto-imported by default."""
+    scripts_dir = tmp_path / "projects" / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / "marker.py").write_text(
+        "\n".join(
+            [
+                "from pathlib import Path",
+                "Path('scripts_imported.txt').write_text('1', encoding='utf-8')",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    marker = tmp_path / "scripts_imported.txt"
+    assert not marker.exists()
+    cp = _run_cli(tmp_path, "upgrade", "--dry-run")
+    assert cp.returncode == 0
+    assert not marker.exists()
+
+
+def test_cli_platform_scripts_imported_when_opted_in(tmp_path: Path) -> None:
+    """CLI-014: `--load-scripts` opts into platform script import."""
+    scripts_dir = tmp_path / "projects" / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / "marker.py").write_text(
+        "\n".join(
+            [
+                "from pathlib import Path",
+                "Path('scripts_imported.txt').write_text('1', encoding='utf-8')",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    marker = tmp_path / "scripts_imported.txt"
+    assert not marker.exists()
+    cp = _run_cli(tmp_path, "--load-scripts", "upgrade", "--dry-run")
+    assert cp.returncode == 0
+    assert marker.exists()


### PR DESCRIPTION
Fixes #9

- Default runs no longer import workspace code under `projects/scripts/*.py`.
- Opt-in via `--load-scripts` (or `PROJMAN_LOAD_SCRIPTS=1`).
- Adds blackbox tests for the new behavior (CLI-013/CLI-014).
