### PR TITLE
fix: redact secrets and summarize command output in logs

### DIFF
--- a/src/log_manager.py
+++ b/src/log_manager.py
@@ -8,6 +8,7 @@ import json
 import logging
 import logging.config
 import os
+import re
 from typing import Any, Optional
 
 from src.utils import get_filename
@@ -25,6 +26,52 @@ LOG_COLORS = {
 }
 RESET_COLOR = "\033[0m"
 
+_REDACTION_RULES: list[tuple[re.Pattern[str], str]] = [
+    # GitHub tokens
+    (re.compile(r"\bghp_[A-Za-z0-9]{36}\b"), "ghp_***"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{30,}\b"), "github_pat_***"),
+    # AWS access keys (best-effort)
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "AKIA****************"),
+    (re.compile(r"\bASIA[0-9A-Z]{16}\b"), "ASIA****************"),
+    # Common auth headers / params
+    (re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._-]+"), "Bearer ***"),
+    (re.compile(r"(?i)\b(access_token|refresh_token|id_token)\s*[:=]\s*([^\s'\"\\]+)"), r"\1=***"),
+    (re.compile(r"(?i)\b(access_token|refresh_token|id_token)=([^&\s]+)"), r"\1=***"),
+    (re.compile(r"(?i)\b(api[_-]?key|token|secret|password)\s*[:=]\s*([^\s'\"\\]+)"), r"\1=***"),
+    (re.compile(r"(?i)\b(api[_-]?key|token|secret|password)=([^&\s]+)"), r"\1=***"),
+    # Basic auth in URLs
+    (re.compile(r"(https?://)([^/@:\s]+):([^@/\s]+)@"), r"\1\2:***@"),
+]
+
+
+def redact_secrets(text: Any) -> str:
+    """Best-effort secret redaction for logs. Keeps output readable."""
+    if text is None:
+        return ""
+    value = str(text)
+    for pattern, replacement in _REDACTION_RULES:
+        value = pattern.sub(replacement, value)
+    return value
+
+
+def summarize_output(text: Any, *, max_tail_lines: int = 20, max_tail_chars: int = 400) -> str:
+    """Summarize potentially-large stdout/stderr for safe logging."""
+    if text is None:
+        return ""
+    value = str(text)
+    if not value:
+        return ""
+    total_len = len(value)
+    lines = value.replace("\r\n", "\n").replace("\r", "\n").splitlines()
+    tail = "\n".join(lines[-max_tail_lines:])
+    if len(tail) > max_tail_chars:
+        tail = tail[-max_tail_chars:]
+    tail = redact_secrets(tail)
+    tail_single = " | ".join(line.strip() for line in tail.splitlines() if line.strip())
+    if len(tail_single) > max_tail_chars:
+        tail_single = tail_single[-max_tail_chars:]
+    return f"[len={total_len} tail={tail_single}]"
+
 
 class ColoredFormatter(logging.Formatter):
     """Formatter with ANSI color codes for log levels."""
@@ -36,6 +83,22 @@ class ColoredFormatter(logging.Formatter):
         formatted = super().format(record)
         # Add color to the whole line
         return f"{color}{formatted}{RESET_COLOR}"
+
+
+class RedactingFormatter(logging.Formatter):
+    """Formatter that redacts common secret patterns from the final log line."""
+
+    def format(self, record):
+        formatted = super().format(record)
+        return redact_secrets(formatted)
+
+
+class RedactingColoredFormatter(ColoredFormatter):
+    """Colored formatter that also redacts common secret patterns."""
+
+    def format(self, record):
+        formatted = super().format(record)
+        return redact_secrets(formatted)
 
 
 class LogManager:
@@ -61,10 +124,11 @@ class LogManager:
             "version": 1.0,
             "formatters": {
                 "console_formatter": {
-                    "()": ColoredFormatter,
+                    "()": RedactingColoredFormatter,
                     "format": "[%(asctime)s] [%(levelname)-8s] [%(filename)-24s] [%(funcName)-24s] [%(lineno)-4d] %(message)s",
                 },
                 "file_formatter": {
+                    "()": RedactingFormatter,
                     "format": "[%(asctime)s] [%(levelname)-8s] [%(filename)-24s] [%(funcName)-24s] [%(lineno)-4d] %(message)s",
                 },
             },

--- a/src/plugins/po_plugins/commits.py
+++ b/src/plugins/po_plugins/commits.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 from typing import Any, Dict, List, Tuple
 
-from src.log_manager import log
+from src.log_manager import log, summarize_output
 
 from .registry import (
     APPLY_PHASE_GLOBAL_PRE,
@@ -131,7 +131,7 @@ def _apply_commits(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                 )
                 continue
 
-            log.error("Failed to apply commit patch '%s': '%s'", patch_file, result.stderr)
+            log.error("Failed to apply commit patch '%s': %s", patch_file, summarize_output(result.stderr))
             return False
 
         head_after = head_before
@@ -210,10 +210,10 @@ def _revert_commits(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                     check=False,
                 )
                 log.debug(
-                    "git revert result: returncode: '%s', stdout: '%s', stderr: '%s'",
+                    "git revert result: returncode=%s stdout=%s stderr=%s",
                     result.returncode,
-                    result.stdout,
-                    result.stderr,
+                    summarize_output(result.stdout),
+                    summarize_output(result.stderr),
                 )
                 if result.returncode != 0:
                     log.error(
@@ -221,7 +221,7 @@ def _revert_commits(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                         sha,
                         ctx.po_name,
                         repo_name,
-                        result.stderr,
+                        summarize_output(result.stderr),
                     )
                     # Best-effort cleanup of revert state.
                     subprocess.run(

--- a/src/plugins/po_plugins/custom.py
+++ b/src/plugins/po_plugins/custom.py
@@ -8,7 +8,7 @@ import glob
 import os
 from typing import Any, Dict, List
 
-from src.log_manager import log
+from src.log_manager import log, summarize_output
 
 from .registry import APPLY_PHASE_PER_PO, REVERT_PHASE_PER_PO, register_simple_plugin
 from .runtime import PoPluginContext, PoPluginRuntime
@@ -152,7 +152,7 @@ def _apply_custom(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                     shell=False,
                 )
                 if result.returncode != 0:
-                    log.error("Failed to copy '%s' to '%s': %s", src, dest, result.stderr)
+                    log.error("Failed to copy '%s' to '%s': %s", src, dest, summarize_output(result.stderr))
                     return False
 
             return True

--- a/src/plugins/po_plugins/overrides.py
+++ b/src/plugins/po_plugins/overrides.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 from typing import Any, Dict, List, Tuple
 
-from src.log_manager import log
+from src.log_manager import log, summarize_output
 
 from .registry import APPLY_PHASE_PER_PO, REVERT_PHASE_PER_PO, register_simple_plugin
 from .runtime import PoPluginContext, PoPluginRuntime
@@ -146,7 +146,7 @@ def _apply_overrides(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                         )
 
                         if result.returncode != 0:
-                            log.error("Failed to remove file '%s': %s", dest_rel, result.stderr)
+                            log.error("Failed to remove file '%s': %s", dest_rel, summarize_output(result.stderr))
                             return False
 
                         log.info("Removed file '%s' (repo_root=%s)", dest_rel, repo_root)
@@ -172,7 +172,12 @@ def _apply_overrides(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                     )
 
                     if result.returncode != 0:
-                        log.error("Failed to copy override file '%s' to '%s': %s", src_file, dest_rel, result.stderr)
+                        log.error(
+                            "Failed to copy override file '%s' to '%s': %s",
+                            src_file,
+                            dest_rel,
+                            summarize_output(result.stderr),
+                        )
                         return False
 
                     log.info("Copied override file '%s' to '%s' (repo_root=%s)", src_file, dest_rel, repo_root)
@@ -283,13 +288,13 @@ def _revert_overrides(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                         check=False,
                     )
                     log.debug(
-                        "git checkout result: returncode: '%s', stdout: '%s', stderr: '%s'",
+                        "git checkout result: returncode=%s stdout=%s stderr=%s",
                         result.returncode,
-                        result.stdout,
-                        result.stderr,
+                        summarize_output(result.stdout),
+                        summarize_output(result.stderr),
                     )
                     if result.returncode != 0:
-                        log.error("Failed to revert override file '%s': '%s'", dest_rel, result.stderr)
+                        log.error("Failed to revert override file '%s': %s", dest_rel, summarize_output(result.stderr))
                         return False
                 elif os.path.exists(dest_abs):
                     log.debug("File '%s' is not tracked by git, deleting directly", dest_rel)

--- a/src/plugins/po_plugins/patches.py
+++ b/src/plugins/po_plugins/patches.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 from typing import Any, Dict, List
 
-from src.log_manager import log
+from src.log_manager import log, summarize_output
 
 from .registry import APPLY_PHASE_PER_PO, REVERT_PHASE_PER_PO, register_simple_plugin
 from .runtime import PoPluginContext, PoPluginRuntime
@@ -85,10 +85,10 @@ def _apply_patches(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
             )
             log.info("applying patch: '%s' to repo: '%s'", patch_file, patch_target)
             log.debug(
-                "git apply result: returncode: '%s', stdout: '%s', stderr: '%s'",
+                "git apply result: returncode=%s stdout=%s stderr=%s",
                 result.returncode,
-                result.stdout,
-                result.stderr,
+                summarize_output(result.stdout),
+                summarize_output(result.stderr),
             )
             if result.returncode != 0:
                 already_applied = runtime.execute_command(
@@ -107,7 +107,7 @@ def _apply_patches(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                     )
                     continue
 
-                log.error("Failed to apply patch '%s': '%s'", patch_file, result.stderr)
+                log.error("Failed to apply patch '%s': %s", patch_file, summarize_output(result.stderr))
                 return False
 
             log.info("patch applied successfully for repo: '%s'", patch_target)
@@ -164,13 +164,13 @@ def _revert_patches(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                     check=False,
                 )
                 log.debug(
-                    "git apply --reverse result: returncode: '%s', stdout: '%s', stderr: '%s'",
+                    "git apply --reverse result: returncode=%s stdout=%s stderr=%s",
                     result.returncode,
-                    result.stdout,
-                    result.stderr,
+                    summarize_output(result.stdout),
+                    summarize_output(result.stderr),
                 )
                 if result.returncode != 0:
-                    log.error("Failed to revert patch '%s': '%s'", patch_file, result.stderr)
+                    log.error("Failed to revert patch '%s': %s", patch_file, summarize_output(result.stderr))
                     return False
                 log.info("patch reverted for dir: '%s'", patch_target)
             except subprocess.SubprocessError as e:

--- a/src/plugins/project_builder.py
+++ b/src/plugins/project_builder.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from src.hooks import HookType, execute_hooks_with_fallback
-from src.log_manager import log
+from src.log_manager import log, summarize_output
 from src.operations.registry import register
 
 # from src.profiler import auto_profile  # unused
@@ -446,7 +446,7 @@ def _repo_sync(ctx: BuildContext) -> bool:
         cmd = _format_cmd_template(cmd, ctx)
         result = _run_cmd(shlex.split(cmd), cwd=cwd, dry_run=ctx.dry_run, description="Sync repositories")
         if result.returncode != 0:
-            log.error("Sync command failed (code=%s): %s", result.returncode, (result.stderr or "").strip())
+            log.error("Sync command failed (code=%s): %s", result.returncode, summarize_output(result.stderr))
             return False
         return True
 
@@ -454,7 +454,7 @@ def _repo_sync(ctx: BuildContext) -> bool:
     if os.path.exists(manifest) and shutil.which("repo"):
         result = _run_cmd(["repo", "sync"], cwd=ctx.root_path, dry_run=ctx.dry_run, description="repo sync")
         if result.returncode != 0:
-            log.error("repo sync failed (code=%s): %s", result.returncode, (result.stderr or "").strip())
+            log.error("repo sync failed (code=%s): %s", result.returncode, summarize_output(result.stderr))
             return False
         return True
 
@@ -494,7 +494,10 @@ def _repo_sync(ctx: BuildContext) -> bool:
         )
         if result.returncode != 0:
             log.error(
-                "git pull failed for '%s' (code=%s): %s", repo_name, result.returncode, (result.stderr or "").strip()
+                "git pull failed for '%s' (code=%s): %s",
+                repo_name,
+                result.returncode,
+                summarize_output(result.stderr),
             )
             return False
 
@@ -535,7 +538,7 @@ def _repo_clean(ctx: BuildContext) -> bool:
                 "git reset failed for '%s' (code=%s): %s",
                 repo_name,
                 reset_result.returncode,
-                (reset_result.stderr or "").strip(),
+                summarize_output(reset_result.stderr),
             )
             return False
 
@@ -553,7 +556,7 @@ def _repo_clean(ctx: BuildContext) -> bool:
                 "git clean failed for '%s' (code=%s): %s",
                 repo_name,
                 clean_result.returncode,
-                (clean_result.stderr or "").strip(),
+                summarize_output(clean_result.stderr),
             )
             return False
 


### PR DESCRIPTION
Fixes #8

- Adds formatter-level redaction for common secret patterns in logs.
- Summarizes git/command stdout/stderr (len + tail) instead of dumping full output.
- Keeps behavior otherwise unchanged.
