### PR TITLE
fix: add --no-fuzzy strict operation resolution

### DIFF
--- a/docs/en/user-guide/command-reference.md
+++ b/docs/en/user-guide/command-reference.md
@@ -20,6 +20,7 @@ All commands accept the following global options:
 | `--help` | Show help for the command or the CLI | `python -m src --help` |
 | `--perf-analyze` | Enable performance analysis logs | `python -m src --perf-analyze po_apply proj1` |
 | `--load-scripts` | Opt-in: import workspace scripts under `projects/scripts/*.py` (unsafe in untrusted workspaces) | `python -m src --load-scripts project_build proj1` |
+| `--no-fuzzy` | Require exact operation match (disable fuzzy matching) | `python -m src --no-fuzzy po_list proj1` |
 | `--safe-mode` | Safe mode for untrusted workspaces (requires explicit confirmation for destructive ops; blocks env-based script loading) | `python -m src --safe-mode po_apply proj1 --dry-run` |
 | `--allow-network` | Safe mode: allow network operations such as `upgrade` | `python -m src --safe-mode --allow-network upgrade --dry-run` |
 | `-y`, `--yes` | Safe mode: explicitly confirm destructive operations (non-interactive) | `python -m src --safe-mode -y po_apply proj1` |

--- a/docs/test_cases_en.md
+++ b/docs/test_cases_en.md
@@ -92,6 +92,7 @@
 | CLI-015 | CLI/Security | `--safe-mode` works with `--help` / `--version` | Dataset A completed | 1. Run `python -m src --safe-mode --help`.<br>2. Run `python -m src --safe-mode --version`. | Both commands exit 0 and print expected output; no operation executed. | P1 | Security |
 | CLI-016 | CLI/Security | Safe mode blocks destructive ops without explicit opt-in | Dataset A completed | 1. Run `python -m src --safe-mode po_apply projA`.<br>2. Run `python -m src --safe-mode project_build projA`. | Each exits non-zero and prints an error requiring `--dry-run` or `--yes`. No destructive action is executed. | P1 | Security |
 | CLI-017 | CLI/Security | Safe mode ignores env-based script loading | Dataset A completed + `projects/scripts/*.py` present | 1. Create `projects/scripts/marker.py` that writes a marker file at import time.<br>2. Run `PROJMAN_LOAD_SCRIPTS=1 python -m src --safe-mode upgrade --dry-run`.<br>3. Check marker file does not exist. | Marker file is not created because safe mode ignores `PROJMAN_LOAD_SCRIPTS` unless `--load-scripts` is explicitly provided. | P1 | Security |
+| CLI-018 | CLI/Arg Parsing | `--no-fuzzy` requires exact operation match | Dataset A completed | 1. Run `python -m src --no-fuzzy buil projA`.<br>2. Run `python -m src --no-fuzzy po projA`. | Each exits non-zero without executing any operation; error indicates fuzzy matching is disabled. | P2 | Safety |
 
 ## 2. Config Loading & Project Index (src/__main__.py)
 

--- a/tests/blackbox/test_cli_no_fuzzy_blackbox_en.py
+++ b/tests/blackbox/test_cli_no_fuzzy_blackbox_en.py
@@ -1,0 +1,26 @@
+"""Blackbox --no-fuzzy operation resolution tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .conftest import run_cli
+
+
+def test_no_fuzzy_rejects_build_prefix(workspace_a: Path) -> None:
+    result = run_cli(["--no-fuzzy", "buil", "projA"], cwd=workspace_a, check=False)
+    assert result.returncode != 0
+    combined = ((result.stdout or "") + (result.stderr or "")).lower()
+    assert "fuzzy matching disabled" in combined
+
+
+def test_no_fuzzy_rejects_ambiguous_po_prefix(workspace_a: Path) -> None:
+    result = run_cli(["--no-fuzzy", "po", "projA"], cwd=workspace_a, check=False)
+    assert result.returncode != 0
+    combined = ((result.stdout or "") + (result.stderr or "")).lower()
+    assert "fuzzy matching disabled" in combined
+
+
+def test_no_fuzzy_exact_operation_still_works(workspace_a: Path) -> None:
+    result = run_cli(["--no-fuzzy", "po_list", "projA", "--short"], cwd=workspace_a, check=False)
+    assert result.returncode == 0


### PR DESCRIPTION
Closes #6

Adds global `--no-fuzzy` flag to require exact operation matching (no fuzzy auto-correct).

Verification:
- `make lint`
- `make test`
