### PR TITLE
Establish mypy baseline ratchet in CI

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,42 @@
+name: mypy
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ["master"]
+    paths:
+      - ".github/workflows/mypy.yml"
+      - "**.py"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - "mypy_baseline.json"
+      - "scripts/mypy_ci.py"
+  pull_request:
+    branches: ["master"]
+    paths:
+      - ".github/workflows/mypy.yml"
+      - "**.py"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - "mypy_baseline.json"
+      - "scripts/mypy_ci.py"
+  workflow_dispatch:
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+      - name: Run mypy (ratcheted baseline)
+        run: |
+          make typecheck
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev test test-cov lint format clean build release docker-build docker-run
+.PHONY: help install install-dev test test-cov lint format typecheck clean build release docker-build docker-run
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -23,6 +23,9 @@ lint: ## Run linting tools
 	black --check src/ tests/ crewai_agents/
 	isort --check-only src/ tests/ crewai_agents/
 	# mypy src/
+
+typecheck: ## Run mypy (ratcheted baseline)
+	python scripts/mypy_ci.py
 
 format: ## Format code
 	black src/ tests/ crewai_agents/

--- a/crewai_agents/crew.py
+++ b/crewai_agents/crew.py
@@ -14,8 +14,13 @@ from typing import Optional
 _CREWAI_IMPORT_ERROR: Optional[Exception] = None
 
 try:
-    from crewai import Agent, Crew, Process, Task  # pylint: disable=import-error
-    from crewai.project import (  # pylint: disable=import-error
+    from crewai import (  # pylint: disable=import-error  # type: ignore[import-not-found]
+        Agent,
+        Crew,
+        Process,
+        Task,
+    )
+    from crewai.project import (  # pylint: disable=import-error  # type: ignore[import-not-found]
         CrewBase,
         agent,
         crew,

--- a/crewai_agents/tools.py
+++ b/crewai_agents/tools.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import os
 import subprocess
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class FileUtils:
@@ -49,7 +49,7 @@ class GitUtils:
     """Git 操作工具"""
 
     @staticmethod
-    def run_git_command(command: List[str], cwd: str = None) -> Dict[str, Any]:
+    def run_git_command(command: List[str], cwd: Optional[str] = None) -> Dict[str, Any]:
         """执行 Git 命令"""
         try:
             result = subprocess.run(
@@ -70,7 +70,7 @@ class GitUtils:
             return {"success": False, "error": str(e)}
 
     @staticmethod
-    def get_current_branch(cwd: str = None) -> str:
+    def get_current_branch(cwd: Optional[str] = None) -> str:
         """获取当前分支"""
         result = GitUtils.run_git_command(["branch", "--show-current"], cwd)
         if result["success"]:
@@ -78,32 +78,39 @@ class GitUtils:
         return "master"
 
     @staticmethod
-    def stage_all(cwd: str = None) -> bool:
+    def stage_all(cwd: Optional[str] = None) -> bool:
         """暂存所有文件"""
         result = GitUtils.run_git_command(["add", "."], cwd)
         return result["success"]
 
     @staticmethod
-    def commit(message: str, cwd: str = None) -> bool:
+    def commit(message: str, cwd: Optional[str] = None) -> bool:
         """提交代码"""
         result = GitUtils.run_git_command(["commit", "-m", message], cwd)
         return result["success"]
 
     @staticmethod
-    def push(cwd: str = None) -> bool:
+    def push(cwd: Optional[str] = None) -> bool:
         """推送代码"""
         branch = GitUtils.get_current_branch(cwd)
         result = GitUtils.run_git_command(["push", "origin", branch], cwd)
         return result["success"]
 
     @staticmethod
-    def generate_commit_message(tasks: List[Dict]) -> str:
+    def generate_commit_message(tasks: List[Dict[str, Any]]) -> str:
         """生成 commit message"""
         if not tasks:
             return "chore: 更新项目"
 
         # 按类型分组
-        types = {"feat": [], "fix": [], "docs": [], "refactor": [], "test": [], "chore": []}
+        types: Dict[str, List[str]] = {
+            "feat": [],
+            "fix": [],
+            "docs": [],
+            "refactor": [],
+            "test": [],
+            "chore": [],
+        }
 
         for task in tasks:
             title = task.get("title", "")
@@ -132,7 +139,7 @@ class TestUtils:
     """测试工具"""
 
     @staticmethod
-    def run_pytest(cwd: str = None, verbose: bool = True) -> Dict[str, Any]:
+    def run_pytest(cwd: Optional[str] = None, verbose: bool = True) -> Dict[str, Any]:
         """运行 pytest"""
         cmd = ["python", "-m", "pytest", "-v", "--tb=short"]
         if not verbose:
@@ -156,7 +163,7 @@ class TestUtils:
             return {"success": False, "error": str(e)}
 
     @staticmethod
-    def check_code_quality(cwd: str = None) -> Dict[str, Any]:
+    def check_code_quality(cwd: Optional[str] = None) -> Dict[str, Any]:
         """检查代码质量 (pylint)"""
         try:
             result = subprocess.run(

--- a/crewai_agents/workflow.py
+++ b/crewai_agents/workflow.py
@@ -15,7 +15,7 @@ import json
 import os
 import sys
 from datetime import datetime
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
 from .tools import FileUtils, GitUtils, TaskManager, TestUtils
 
@@ -29,7 +29,7 @@ class Agent:
         self.goal = goal
         self.backstory = backstory
 
-    def execute(self, task: str, context: Dict = None) -> str:
+    def execute(self, task: str, context: Optional[Dict[str, Any]] = None) -> str:
         """执行任务"""
         print(f"\n🤖 {self.name} ({self.role}) 执行任务...")
         print(f"   目标: {self.goal}")
@@ -102,7 +102,7 @@ class RequirementAnalystAgent(Agent):
 
     def _check_conflicts(self, requirements: str) -> List[str]:
         # 检查是否与现有功能冲突
-        conflicts = []
+        conflicts: List[str] = []
         # 实际应该检查现有代码和文档
         return conflicts
 

--- a/mypy_baseline.json
+++ b/mypy_baseline.json
@@ -1,0 +1,8 @@
+{
+  "baseline_error_count": 23,
+  "command": "python -m mypy src crewai_agents --no-color-output",
+  "targets": [
+    "src",
+    "crewai_agents"
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "black==24.8.0",
     "isort==5.13.2",
     "mypy>=1.5.0",
+    "types-toml>=0.10.8",
     "pre-commit>=3.3.0",
     "crewai>=0.80.0",
 ]
@@ -116,26 +117,18 @@ multi_line_output = 3
 line_length = 88
 known_first_party = ["src"]
 
-# [tool.mypy]
-# python_version = "3.8"
-# warn_return_any = true
-# warn_unused_configs = true
-# disallow_untyped_defs = true
-# disallow_incomplete_defs = true
-# check_untyped_defs = true
-# disallow_untyped_decorators = true
-# no_implicit_optional = true
-# warn_redundant_casts = true
-# warn_unused_ignores = true
-# warn_no_return = true
-# warn_unreachable = true
-# strict_equality = true
+[tool.mypy]
+python_version = "3.9"
+warn_unused_configs = true
+no_implicit_optional = true
+show_error_codes = true
 
-# [[tool.mypy.overrides]]
-# module = [
-#     "GitPython.*",
-# ]
-# ignore_missing_imports = true
+[[tool.mypy.overrides]]
+module = [
+    "crewai",
+    "crewai.*",
+]
+ignore_missing_imports = true
 
 [tool.pylint.main]
 fail-under = 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pylint>=3.0.0,<4
 black==24.8.0
 isort==5.13.2
 mypy>=1.5.0
+types-toml>=0.10.8
 
 # Optional: for better development experience
 pre-commit>=3.3.0

--- a/scripts/mypy_ci.py
+++ b/scripts/mypy_ci.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+CI helper for incremental mypy adoption.
+
+Runs mypy and enforces that the total error count does not exceed the baseline
+stored in `mypy_baseline.json`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BASELINE_PATH = ROOT / "mypy_baseline.json"
+
+
+def _run_mypy(targets: List[str]) -> Tuple[int, str]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "mypy",
+        *targets,
+        "--no-color-output",
+    ]
+    proc = subprocess.run(cmd, cwd=str(ROOT), capture_output=True, text=True, check=False)
+    output = (proc.stdout or "") + (proc.stderr or "")
+
+    if proc.returncode == 0:
+        return 0, output
+
+    match = re.search(r"Found\s+(\d+)\s+errors?\s+in\s+", output)
+    if match:
+        return int(match.group(1)), output
+
+    # Fallback: count error lines if summary is missing (e.g., crash/interrupt).
+    error_lines = [line for line in output.splitlines() if ": error:" in line]
+    if error_lines:
+        return len(error_lines), output
+
+    raise RuntimeError(f"mypy failed without a parsable summary (exit={proc.returncode}).\n{output}")
+
+
+def _load_baseline() -> Dict[str, Any]:
+    if not BASELINE_PATH.exists():
+        raise FileNotFoundError(f"Missing baseline file: {BASELINE_PATH}")
+    return json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+
+
+def _write_baseline(*, error_count: int, targets: List[str], command: str) -> None:
+    payload: Dict[str, Any] = {
+        "baseline_error_count": error_count,
+        "targets": targets,
+        "command": command,
+    }
+    BASELINE_PATH.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run mypy and enforce baseline error count.")
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Update mypy_baseline.json with the current error count.",
+    )
+    parser.add_argument(
+        "--targets",
+        nargs="*",
+        default=["src", "crewai_agents"],
+        help="Directories/packages passed to mypy.",
+    )
+    args = parser.parse_args()
+
+    targets = list(args.targets)
+    # Avoid embedding machine-specific absolute paths in the committed baseline.
+    command = f"python -m mypy {' '.join(targets)} --no-color-output"
+
+    errors, output = _run_mypy(targets)
+
+    if args.update_baseline:
+        _write_baseline(error_count=errors, targets=targets, command=command)
+        print(f"Updated baseline: {errors} errors")
+        return 0
+
+    baseline = _load_baseline()
+    baseline_errors = int(baseline.get("baseline_error_count", 0))
+
+    if errors > baseline_errors:
+        print(f"mypy errors increased: {errors} > baseline {baseline_errors}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("To accept a new baseline (not recommended unless intentional):", file=sys.stderr)
+        print(f"  {sys.executable} scripts/mypy_ci.py --update-baseline", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("mypy output (tail):", file=sys.stderr)
+        tail = "\n".join(output.splitlines()[-60:])
+        print(tail, file=sys.stderr)
+        return 1
+
+    print(f"mypy ok: {errors} errors (baseline {baseline_errors})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/plugins/doctor.py
+++ b/src/plugins/doctor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json as jsonlib
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from src.log_manager import log
 from src.operations.registry import register
@@ -160,7 +160,7 @@ def doctor(env: Dict[str, Any], projects_info: Dict[str, Any], json: bool = Fals
                 try:
                     with open(ini_path, "r", encoding="utf-8") as f:
                         current_section = None
-                        keys_in_section = set()
+                        keys_in_section: Set[str] = set()
                         for raw_line in f:
                             line = raw_line.strip()
                             if not line or line.startswith(";") or line.startswith("#"):

--- a/src/plugins/upgrader.py
+++ b/src/plugins/upgrader.py
@@ -17,7 +17,7 @@ import subprocess
 import tempfile
 import urllib.error
 import urllib.request
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 
 from src.log_manager import log
 from src.operations.registry import register
@@ -50,7 +50,10 @@ def _is_admin_user() -> bool:
         try:
             import ctypes
 
-            return bool(ctypes.windll.shell32.IsUserAnAdmin())
+            windll = getattr(ctypes, "windll", None)
+            if windll is None:
+                return False
+            return bool(windll.shell32.IsUserAnAdmin())
         except (AttributeError, OSError):
             return False
 
@@ -75,7 +78,7 @@ def _resolve_install_dir(
     install_mode: str,
     prefix: str,
     is_admin: bool,
-    env_vars: Dict[str, str],
+    env_vars: Mapping[str, str],
 ) -> str:
     if prefix:
         return os.path.abspath(os.path.expanduser(prefix))


### PR DESCRIPTION
Closes #12

Source: run_id=20260215-173843-1416 (finding F-0006)
Evidence: E-0023, E-0024, E-0025

What changed:
- Add `scripts/mypy_ci.py` + `mypy_baseline.json` to enforce a non-increasing mypy error count.
- Add `make typecheck` target.
- Add `.github/workflows/mypy.yml` CI job.
- Add minimal mypy config in `pyproject.toml`.
- Add `types-toml` stubs; fix a few low-noise typing issues in optional modules.

Verification:
- make format
- make lint
- make test
- make typecheck

Rollback:
- Revert the PR merge commit on master.
