### PR TITLE
feat: add --emit-plan execution plans

### DIFF
--- a/docs/en/user-guide/command-reference.md
+++ b/docs/en/user-guide/command-reference.md
@@ -126,13 +126,16 @@ python -m src project_del myproject
 
 **Syntax**
 ```bash
-python -m src project_build <project-name>
+python -m src project_build <project-name> [--emit-plan [<path>]]
 ```
 
 **Description**: Build the specified project according to its configuration.
 
 **Arguments**
 - `project-name` (required): Name of the project to build.
+
+**Options**
+- `--emit-plan`: Emit a machine-readable JSON execution plan to stdout (or to `<path>` when provided) without executing any build steps.
 
 **Example**
 ```bash
@@ -147,7 +150,7 @@ python -m src project_build myproject
 
 **Syntax**
 ```bash
-python -m src project_diff <project-name> [--keep-diff-dir] [--dry-run]
+python -m src project_diff <project-name> [--keep-diff-dir] [--dry-run] [--emit-plan [<path>]]
 ```
 
 **Description**: Generate a timestamped diff directory under `.cache/build/<project-name>/<timestamp>/diff` and archive it as `diff_<project>_<timestamp>.tar.gz`.
@@ -158,6 +161,7 @@ python -m src project_diff <project-name> [--keep-diff-dir] [--dry-run]
 **Options**
 - `--keep-diff-dir`: Preserve the diff directory after creating the tar.gz archive.
 - `--dry-run`: Print planned actions without creating files/directories.
+- `--emit-plan`: Emit a machine-readable JSON execution plan to stdout (or to `<path>` when provided) without writing any diff output.
 
 **Example**
 ```bash
@@ -288,7 +292,7 @@ python -m src board_del myboard
 
 **Syntax**
 ```bash
-python -m src po_apply <project-name> [--dry-run] [--force] [--reapply] [--po <po1,po2>]
+python -m src po_apply <project-name> [--dry-run] [--emit-plan [<path>]] [--force] [--reapply] [--po <po1,po2>]
 ```
 
 **Description**: Apply all configured patches and overrides for the target project.
@@ -298,6 +302,7 @@ python -m src po_apply <project-name> [--dry-run] [--force] [--reapply] [--po <p
 
 **Options**
 - `--dry-run`: Print planned actions without modifying files.
+- `--emit-plan`: Emit a machine-readable JSON execution plan to stdout (or to `<path>` when provided) without modifying repositories.
 - `--force`: Allow destructive operations (for example, override `.remove` deletions) and allow custom copy targets outside the workspace/repositories.
 - `--reapply`: Apply a PO even if applied records already exist (ignores existing markers and overwrites them after success).
 - `--po`: Apply only the selected PO(s) from `PROJECT_PO_CONFIG` (comma/space separated).
@@ -322,7 +327,7 @@ python -m src po_apply myproject
 
 **Syntax**
 ```bash
-python -m src po_revert <project-name> [--dry-run] [--po <po1,po2>]
+python -m src po_revert <project-name> [--dry-run] [--emit-plan [<path>]] [--po <po1,po2>]
 ```
 
 **Description**: Revert the previously applied patches and overrides for the project, and remove applied record markers so the PO can be applied again.
@@ -332,6 +337,7 @@ python -m src po_revert <project-name> [--dry-run] [--po <po1,po2>]
 
 **Options**
 - `--dry-run`: Print planned actions without modifying files.
+- `--emit-plan`: Emit a machine-readable JSON execution plan to stdout (or to `<path>` when provided) without modifying repositories.
 - `--po`: Revert only the selected PO(s) from `PROJECT_PO_CONFIG` (comma/space separated).
 
 **Example**

--- a/docs/test_cases_en.md
+++ b/docs/test_cases_en.md
@@ -241,3 +241,12 @@
 | DRY-001 | Safety | `project_diff --dry-run` prints plan and does not write | Dataset A or B completed | 1. Run `python -m src project_diff projA --dry-run`.<br>2. Check filesystem for `.cache/build/.../diff`. | Logs show planned diff root/repositories; no `.cache/build/.../diff` directories are created. | P1 | Safety |
 | DRY-002 | Safety | `po_apply --dry-run` prints plan and does not write | Dataset A completed with patches/overrides/custom configured | 1. Run `python -m src po_apply projA --dry-run`.<br>2. Check that repo files are unchanged. | Logs show planned `git apply`/copy/remove actions; no repo writes occur; no `po_applied` flag is created. | P0 | Safety |
 | DRY-003 | Safety | `po_revert --dry-run` prints plan and does not write | Dataset A completed with applyable PO | 1. Run `python -m src po_revert projA --dry-run`.<br>2. Check that repo files are unchanged. | Logs show planned `git apply --reverse`/checkout/remove actions; no repo writes occur. | P0 | Safety |
+
+## 12. Execution Plan Export (--emit-plan)
+
+| Case ID | Module | Title | Preconditions | Steps | Expected Result | Priority | Type |
+|---|---|---|---|---|---|---|---|
+| PLAN-001 | DX/Safety | `project_diff --emit-plan` outputs JSON and does not write | Dataset A or B completed | 1. Run `python -m src project_diff projA --emit-plan`.<br>2. Parse stdout as JSON. | JSON contains `schema_version`, `operation=project_diff`, per-repo file lists; no `.cache` output is created. | P1 | DX |
+| PLAN-002 | DX/Safety | `po_apply --emit-plan` outputs JSON and does not write | Dataset A completed | 1. Run `python -m src po_apply projA --emit-plan`.<br>2. Parse stdout as JSON. | JSON contains `schema_version`, `operation=po_apply`, per-repo actions; no repo files are modified and no applied records are written. | P1 | DX |
+| PLAN-003 | DX/Safety | `po_revert --emit-plan` outputs JSON and does not write | Dataset A completed | 1. Run `python -m src po_revert projA --emit-plan`.<br>2. Parse stdout as JSON. | JSON contains `schema_version`, `operation=po_revert`, per-repo actions; no repo files are modified and no applied records are removed. | P1 | DX |
+| PLAN-004 | DX/Safety | `project_build --emit-plan` outputs JSON and does not write | Dataset A completed | 1. Run `python -m src project_build projA --emit-plan`.<br>2. Parse stdout as JSON. | JSON contains `schema_version`, `operation=project_build`, step list (including pre-build nested plans); no `.cache` output is created. | P1 | DX |

--- a/docs/zh/user-guide/command-reference.md
+++ b/docs/zh/user-guide/command-reference.md
@@ -72,13 +72,16 @@ python -m src project_del myproject
 
 **语法**:
 ```bash
-python -m src project_build <项目名称>
+python -m src project_build <项目名称> [--emit-plan [<path>]]
 ```
 
 **描述**: 根据配置构建指定项目。
 
 **参数**:
 - `项目名称`（必需）: 要构建的项目名称
+
+**选项**:
+- `--emit-plan`: 输出机器可读的 JSON 执行计划到 stdout（或写入 `<path>`），且不会真正执行构建步骤。
 
 **示例**:
 ```bash
@@ -93,7 +96,7 @@ python -m src project_build myproject
 
 **语法**:
 ```bash
-python -m src project_diff <项目名称> [--keep-diff-dir] [--dry-run]
+python -m src project_diff <项目名称> [--keep-diff-dir] [--dry-run] [--emit-plan [<path>]]
 ```
 
 **描述**: 在 `.cache/build/<项目名称>/<时间戳>/diff` 生成 diff 目录，并归档为 `diff_<项目>_<时间戳>.tar.gz`。
@@ -104,6 +107,7 @@ python -m src project_diff <项目名称> [--keep-diff-dir] [--dry-run]
 **选项**:
 - `--keep-diff-dir`: 创建 tar.gz 后保留 diff 目录。
 - `--dry-run`: 仅打印计划执行的动作，不创建文件/目录。
+- `--emit-plan`: 输出机器可读的 JSON 执行计划到 stdout（或写入 `<path>`），且不会写入任何 diff 输出。
 
 **示例**:
 ```bash
@@ -234,7 +238,7 @@ python -m src board_del myboard
 
 **语法**:
 ```bash
-python -m src po_apply <项目名称> [--dry-run] [--force] [--reapply] [--po <po1,po2>]
+python -m src po_apply <项目名称> [--dry-run] [--emit-plan [<path>]] [--force] [--reapply] [--po <po1,po2>]
 ```
 
 **描述**: 为指定项目应用所有配置的补丁和覆盖。
@@ -244,6 +248,7 @@ python -m src po_apply <项目名称> [--dry-run] [--force] [--reapply] [--po <p
 
 **选项**:
 - `--dry-run`: 仅打印计划执行的动作，不修改文件。
+- `--emit-plan`: 输出机器可读的 JSON 执行计划到 stdout（或写入 `<path>`），且不会修改仓库内容。
 - `--force`: 允许执行带破坏性的操作（例如覆盖 `.remove` 删除），并允许 custom copy 目标路径位于工作区/仓库之外。
 - `--reapply`: 即使已存在已应用记录，也强制重新应用（成功后会覆盖对应记录文件）。
 - `--po`: 仅应用指定的 PO（从 `PROJECT_PO_CONFIG` 中筛选，逗号/空格分隔）。
@@ -276,7 +281,7 @@ python -m src po_apply myproject
 
 **语法**:
 ```bash
-python -m src po_revert <项目名称> [--dry-run] [--po <po1,po2>]
+python -m src po_revert <项目名称> [--dry-run] [--emit-plan [<path>]] [--po <po1,po2>]
 ```
 
 **描述**: 回滚指定项目的所有已应用补丁和覆盖，并清理已应用记录，使后续可再次应用。
@@ -286,6 +291,7 @@ python -m src po_revert <项目名称> [--dry-run] [--po <po1,po2>]
 
 **选项**:
 - `--dry-run`: 仅打印计划执行的动作，不修改文件。
+- `--emit-plan`: 输出机器可读的 JSON 执行计划到 stdout（或写入 `<path>`），且不会修改仓库内容。
 - `--po`: 仅回滚指定的 PO（从 `PROJECT_PO_CONFIG` 中筛选，逗号/空格分隔）。
 
 **流程**:

--- a/src/plan_utils.py
+++ b/src/plan_utils.py
@@ -1,0 +1,72 @@
+"""
+Utilities for emitting machine-readable execution plans.
+
+This is intentionally lightweight and has no side effects beyond writing the
+requested plan JSON to stdout or a file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Dict, Optional, Tuple
+
+from src.log_manager import redact_secrets
+
+_TRUTHY = {"1", "true", "yes", "y", "on"}
+_FALSY = {"0", "false", "no", "n", "off"}
+
+
+def parse_emit_plan(value: Any) -> Tuple[bool, Optional[str]]:
+    """Return (enabled, path). When enabled and path is None, emit to stdout."""
+    if value in (None, False):
+        return False, None
+    if value is True:
+        return True, None
+
+    text = str(value).strip()
+    if not text:
+        return False, None
+    lowered = text.lower()
+    if lowered in _TRUTHY:
+        return True, None
+    if lowered in _FALSY:
+        return False, None
+    return True, text
+
+
+def _redact_payload(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return redact_secrets(value)
+    if isinstance(value, list):
+        return [_redact_payload(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _redact_payload(v) for k, v in value.items()}
+    return value
+
+
+def emit_plan_json(payload: Dict[str, Any], emit_plan: Any) -> bool:
+    """Emit a redacted JSON payload to stdout or to the provided path."""
+    enabled, out_path = parse_emit_plan(emit_plan)
+    if not enabled:
+        return False
+
+    redacted = _redact_payload(payload)
+    text = json.dumps(redacted, indent=2, ensure_ascii=False) + "\n"
+
+    if out_path:
+        out_path = os.path.expanduser(out_path)
+        out_dir = os.path.dirname(out_path)
+        if out_dir:
+            os.makedirs(out_dir, exist_ok=True)
+        tmp_path = f"{out_path}.tmp"
+        with open(tmp_path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_path, out_path)
+        return True
+
+    sys.stdout.write(text)
+    return True

--- a/tests/whitebox/plugins/test_patch_override.py
+++ b/tests/whitebox/plugins/test_patch_override.py
@@ -392,6 +392,54 @@ class TestPatchOverrideApply:
             # Custom copy target not created.
             assert not os.path.exists(os.path.join(tmpdir, "custom_dest.txt"))
 
+    def test_po_apply_emit_plan_outputs_json_and_no_side_effects(self, capsys):
+        """PLAN-002: po_apply --emit-plan emits JSON and does not write."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_path = os.path.join(tmpdir, "projects")
+            board_name = "board"
+            po_name = "po1"
+            project_name = "proj"
+
+            repo_root = os.path.join(tmpdir, "repo_root")
+            os.makedirs(repo_root, exist_ok=True)
+            target_file = os.path.join(repo_root, "target.txt")
+            with open(target_file, "w", encoding="utf-8") as f:
+                f.write("original\n")
+
+            overrides_dir = os.path.join(projects_path, board_name, "po", po_name, "overrides")
+            os.makedirs(overrides_dir, exist_ok=True)
+            with open(os.path.join(overrides_dir, "target.txt"), "w", encoding="utf-8") as f:
+                f.write("override\n")
+
+            env = {
+                "projects_path": projects_path,
+                "repositories": [(repo_root, "root")],
+                "po_configs": {},
+            }
+            projects_info = {project_name: {"board_name": board_name, "config": {"PROJECT_PO_CONFIG": po_name}}}
+
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                result = self.PatchOverride.po_apply(env, projects_info, project_name, emit_plan=True)
+            finally:
+                os.chdir(old_cwd)
+
+            assert result is True
+            payload = json.loads(capsys.readouterr().out)
+            assert payload["schema_version"] == 1
+            assert payload["operation"] == "po_apply"
+            assert payload["project_name"] == project_name
+            assert payload["dry_run"] is True
+            assert payload["per_repo_actions"][0]["repo"] == "root"
+
+            # No applied record written.
+            record_path = self.PatchOverride._po_applied_record_path(repo_root, board_name, project_name, po_name)
+            assert not os.path.exists(record_path)
+            # Repository content unchanged.
+            with open(target_file, "r", encoding="utf-8") as f:
+                assert f.read() == "original\n"
+
     def test_po_apply_custom_copy_outside_workspace_requires_force(self):
         """Custom copy refuses targets outside workspace/repositories unless --force is set."""
         with tempfile.TemporaryDirectory() as tmpdir, tempfile.TemporaryDirectory() as outside_dir:
@@ -466,6 +514,55 @@ class TestPatchOverrideApply:
 
             result = self.PatchOverride.po_revert(env, projects_info, project_name, dry_run=True)
             assert result is True
+            with open(tracked, "r", encoding="utf-8") as f:
+                assert f.read() == "modified\n"
+
+    def test_po_revert_emit_plan_outputs_json_and_no_side_effects(self, capsys):
+        """PLAN-003: po_revert --emit-plan emits JSON and does not write."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_path = os.path.join(tmpdir, "projects")
+            board_name = "board"
+            po_name = "po1"
+            project_name = "proj"
+
+            repo_root = os.path.join(tmpdir, "repo_root")
+            os.makedirs(repo_root, exist_ok=True)
+            subprocess.run(["git", "init"], cwd=repo_root, check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_root, check=True)
+            subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_root, check=True)
+
+            tracked = os.path.join(repo_root, "tracked.txt")
+            with open(tracked, "w", encoding="utf-8") as f:
+                f.write("base\n")
+            subprocess.run(["git", "add", "tracked.txt"], cwd=repo_root, check=True)
+            subprocess.run(["git", "commit", "-m", "base"], cwd=repo_root, check=True)
+
+            # Modify tracked file (should remain modified).
+            with open(tracked, "w", encoding="utf-8") as f:
+                f.write("modified\n")
+
+            overrides_dir = os.path.join(projects_path, board_name, "po", po_name, "overrides")
+            os.makedirs(overrides_dir, exist_ok=True)
+            with open(os.path.join(overrides_dir, "tracked.txt"), "w", encoding="utf-8") as f:
+                f.write("override\n")
+
+            env = {"projects_path": projects_path, "repositories": [(repo_root, "root")], "po_configs": {}}
+            projects_info = {project_name: {"board_name": board_name, "config": {"PROJECT_PO_CONFIG": po_name}}}
+
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                result = self.PatchOverride.po_revert(env, projects_info, project_name, emit_plan=True)
+            finally:
+                os.chdir(old_cwd)
+
+            assert result is True
+            payload = json.loads(capsys.readouterr().out)
+            assert payload["schema_version"] == 1
+            assert payload["operation"] == "po_revert"
+            assert payload["project_name"] == project_name
+            assert payload["dry_run"] is True
+
             with open(tracked, "r", encoding="utf-8") as f:
                 assert f.read() == "modified\n"
 


### PR DESCRIPTION
Closes #17

## What
- Add `--emit-plan` to `po_apply`, `po_revert`, `project_diff`, and `project_build` to emit a machine-readable JSON plan to stdout (or a file path).
- Plans are redacted (best-effort) and do not write repo/build outputs.
- Add plan test cases and unit coverage.

## Evidence
- run_id: 20260215-173843-1416
- evidence: E-0007, E-0002

## Verification
- `make format`
- `make lint`
- `make test`

## Rollback
- Revert commit `5247521`.