### PR TITLE
feat: add po_analyze conflict analyzer

### DIFF
--- a/docs/en/user-guide/command-reference.md
+++ b/docs/en/user-guide/command-reference.md
@@ -347,6 +347,32 @@ python -m src po_revert myproject
 
 ---
 
+### `po_analyze` — Analyze PO conflicts
+
+**Status**: ✅ Implemented
+
+**Syntax**
+```bash
+python -m src po_analyze <project-name> [--json] [--strict] [--po <po1,po2>]
+```
+
+**Description**: Analyze enabled POs for overlapping patch targets and override targets (useful for CI gating and reviews).
+
+**Arguments**
+- `project-name` (required): Project whose PO set should be analyzed.
+
+**Options**
+- `--json`: Output a machine-readable JSON report to stdout.
+- `--strict`: Exit non-zero when conflicts are detected.
+- `--po`: Analyze only the selected PO(s) from `PROJECT_PO_CONFIG` (comma/space separated).
+
+**Example**
+```bash
+python -m src po_analyze myproject --json --strict
+```
+
+---
+
 ### `po_new` — Create a PO directory
 
 **Status**: ✅ Implemented

--- a/docs/test_cases_en.md
+++ b/docs/test_cases_en.md
@@ -200,6 +200,7 @@
 | PO-022 | PO Delete | po_del cancelled by user | PO exists | 1. Run `python -m src po_del projA po_base`.<br>2. Enter `no`. | Deletion cancelled; PO directory and config unchanged. | P2 | Compatibility |
 | PO-023 | PO List | po_list short names only | Dataset A completed | 1. Run `python -m src po_list projA --short`. | Only PO names printed. | P1 | Functional |
 | PO-024 | PO List | po_list detailed output | Dataset A completed | 1. Run `python -m src po_list projA`. | Outputs commits, patches, overrides, and custom file lists. | P1 | Functional |
+| PO-025 | PO Analyze | po_analyze detects conflicts (JSON) | Dataset A completed with two POs touching same path | 1. Prepare two POs that both touch the same file via patches and/or overrides.<br>2. Run `python -m src po_analyze projA --json`.<br>3. Inspect `conflicts.overrides` and `conflicts.patches`. | JSON includes overlapping paths with the list of POs. Multi-repo targets are reported as `repo1/path/to/file`. | P1 | DX |
 
 ## 9. Utilities & Logging (src/utils.py / src/log_manager.py / src/profiler.py)
 

--- a/docs/zh/user-guide/command-reference.md
+++ b/docs/zh/user-guide/command-reference.md
@@ -307,6 +307,32 @@ python -m src po_revert myproject
 
 ---
 
+### `po_analyze` - 分析 PO 冲突
+
+**状态**: ✅ 已实现
+
+**语法**:
+```bash
+python -m src po_analyze <项目名称> [--json] [--strict] [--po <po1,po2>]
+```
+
+**描述**: 分析启用的 PO 是否存在补丁目标或覆盖目标的重叠（适用于 CI gate 和评审前检查）。
+
+**参数**:
+- `项目名称`（必需）: 要分析 PO 的项目名称
+
+**选项**:
+- `--json`: 输出机器可读的 JSON 报告到 stdout
+- `--strict`: 当检测到冲突时以非 0 退出
+- `--po`: 仅分析指定的 PO（从 `PROJECT_PO_CONFIG` 中筛选，逗号/空格分隔）
+
+**示例**:
+```bash
+python -m src po_analyze myproject --json --strict
+```
+
+---
+
 ### `po_new` - 创建新PO目录
 
 **状态**: ✅ 已实现


### PR DESCRIPTION
Closes #18

## What
- Add `po_analyze` to detect overlapping patch targets and override targets across enabled POs.
- Supports multi-repo prefixing (e.g. `repo1/path`).
- Supports `--json` output and `--strict` for CI gating.

## Evidence
- run_id: 20260215-173843-1416
- evidence: E-0007, E-0002

## Verification
- `make format`
- `make lint`
- `make test`

## Rollback
- Revert commit `336b475`.