### PR TITLE
feat: add optional TUI dependency + --tui plumbing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,13 @@ dev = [
     "mypy>=1.5.0",
     "types-toml>=0.10.8",
     "pre-commit>=3.3.0",
+    "questionary>=2.1.0",
     "crewai>=0.80.0",
+]
+
+# Optional TUI support (prompt_toolkit-based)
+tui = [
+    "questionary>=2.1.0",
 ]
 
 # Optional CrewAI workflow support (requires newer Python)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,8 @@ types-toml>=0.10.8
 # Optional: for better development experience
 pre-commit>=3.3.0
 
+# Optional TUI support (install via `pip install -e ".[tui]"`)
+questionary>=2.1.0
+
 # CrewAI support is optional. Install with:
 #   pip install -e ".[crewai]"

--- a/src/plugins/patch_override.py
+++ b/src/plugins/patch_override.py
@@ -890,6 +890,7 @@ def po_new(
     project_name: str,
     po_name: str,
     force: bool = False,
+    tui: bool = False,
     po_check_exists: bool = False,
 ) -> bool:
     """
@@ -1560,6 +1561,16 @@ def po_new(
     try:
         # Interactive file selection first
         if not force:
+            if tui:
+                from src.tui_utils import tui_available
+
+                ok, msg = tui_available()
+                if not ok:
+                    log.error("%s", msg)
+                    print(msg)
+                    return False
+                print("NOTE: --tui is enabled, but TUI UI is not implemented yet; falling back to prompt-based flow.")
+
             # Pass env["repositories"] and project_cfg for interactive selection.
             __interactive_file_selection(po_path, env.get("repositories", []), project_cfg)
 
@@ -1585,12 +1596,14 @@ def po_new(
 
 
 @register("po_update", needs_repositories=True, desc="Update an existing PO for a project")
-def po_update(env: Dict, projects_info: Dict, project_name: str, po_name: str, force: bool = False) -> bool:
+def po_update(
+    env: Dict, projects_info: Dict, project_name: str, po_name: str, force: bool = False, tui: bool = False
+) -> bool:
     """
     Update an existing PO directory structure (must already exist).
     Reuses po_new with po_update=True to leverage the same workflow.
     """
-    return po_new(env, projects_info, project_name, po_name, force=force, po_check_exists=True)
+    return po_new(env, projects_info, project_name, po_name, force=force, tui=tui, po_check_exists=True)
 
 
 @register("po_del", needs_repositories=True, desc="Delete a PO for a project")

--- a/src/tui_utils.py
+++ b/src/tui_utils.py
@@ -1,0 +1,45 @@
+"""Optional TUI helpers.
+
+This module intentionally imports optional dependencies lazily, so that the
+default CLI remains usable without extra packages.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Tuple
+
+INSTALL_HINT = 'pip install -e ".[tui]"'
+
+
+class TuiUnavailable(RuntimeError):
+    """Raised when TUI mode cannot be used (missing deps or no TTY)."""
+
+
+def _is_tty() -> bool:
+    try:
+        return bool(sys.stdin.isatty() and sys.stdout.isatty())
+    except (AttributeError, OSError, ValueError):  # pragma: no cover
+        return False
+
+
+def get_questionary(*, require_tty: bool = True) -> Any:
+    """Import and return `questionary`, raising a user-friendly error if unavailable."""
+    if require_tty and not _is_tty():
+        raise TuiUnavailable("TUI requires an interactive TTY (stdin/stdout).")
+
+    try:
+        import questionary  # type: ignore
+    except ModuleNotFoundError as exc:
+        raise TuiUnavailable(f"TUI dependency is not installed. Install it with: {INSTALL_HINT}") from exc
+
+    return questionary
+
+
+def tui_available(*, require_tty: bool = True) -> Tuple[bool, str]:
+    """Return (ok, message) for whether TUI mode can be used in this environment."""
+    try:
+        get_questionary(require_tty=require_tty)
+    except TuiUnavailable as exc:
+        return False, str(exc)
+    return True, ""


### PR DESCRIPTION
Closes #35

## What
- Add optional `tui` extra (`questionary`) and include it in dev/CI deps.
- Add `src/tui_utils.py` to lazily import optional TUI deps and provide user-friendly errors.
- Plumb `--tui` flag for `po_new`/`po_update` (currently falls back to the existing prompt-based flow; actual UI comes in #36/#37).

## Verification
- `make format`
- `make lint`
- `make test`

## Rollback
- Revert the merge commit, or revert this PR.
