### PR TITLE
feat(ai): add ai_review for git diffs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Optional AI/LLM features (default off)
+#
+# Usage:
+# - Copy to .env and fill values, OR export environment variables directly.
+# - .env is gitignored by default in this repo.
+#
+# API key (choose one)
+PROJMAN_LLM_API_KEY=
+# OPENAI_API_KEY=
+#
+# OpenAI-compatible endpoint + model
+PROJMAN_LLM_BASE_URL=https://api.openai.com/v1
+PROJMAN_LLM_MODEL=gpt-4o-mini
+#
+# Safety / limits
+PROJMAN_LLM_TIMEOUT_SEC=30
+PROJMAN_LLM_MAX_INPUT_CHARS=12000
+PROJMAN_LLM_MAX_OUTPUT_TOKENS=700
+PROJMAN_LLM_TEMPERATURE=0.2
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,9 @@
 # TODO
+
+- [x] F-0011: Avoid stdout writes during log initialization (MCP-safe)
+- [ ] NF-0007: AI code review for git diff (ai_review)
+- [ ] NF-0008: MCP server MVP (read-only tools)
+- [ ] NF-0009: AI debug assistant for logs/CI failures (ai_explain)
+- [ ] NF-0010: AI docs assistant (generate README/docs snippets with citations)
+- [ ] NF-0011: AI test generator (suggest + scaffold unit tests)
+- [ ] NF-0012: Semantic code search (optional embeddings index)

--- a/build.sh
+++ b/build.sh
@@ -121,11 +121,13 @@ pyinstaller \
     --hidden-import=src.plugins.patch_override \
     --hidden-import=src.plugins.doctor \
     --hidden-import=src.plugins.snapshot \
+    --hidden-import=src.plugins.ai_review \
     --hidden-import=src.plugins.po_plugins \
     --hidden-import=src.operations.registry \
     --hidden-import=src.log_manager \
     --hidden-import=src.profiler \
     --hidden-import=src.utils \
+    --hidden-import=src.ai.llm \
     --hidden-import=src._build_info \
     "${IMPORTLIB_METADATA_ARGS[@]}" \
     --collect-all=git \

--- a/docs/en/user-guide/command-reference.md
+++ b/docs/en/user-guide/command-reference.md
@@ -74,6 +74,46 @@ python -m src doctor --strict
 
 ---
 
+## AI Commands
+
+### `ai_review` — AI-assisted review of git changes
+
+**Status**: ✅ Implemented
+
+**Syntax**
+```bash
+python -m src ai_review [repo] [--staged] [--allow-send-diff] [--dry-run] [--out <path>] [--max-input-chars <n>]
+```
+
+**Description**: Generate an AI-assisted review of local git changes. Safe-by-default: without `--allow-send-diff`, it only sends `git status --porcelain` and `git diff --stat` to the LLM.
+
+**Configuration**
+- Required (unless `--dry-run`): `PROJMAN_LLM_API_KEY` (or `OPENAI_API_KEY`)
+- Optional: `PROJMAN_LLM_BASE_URL`, `PROJMAN_LLM_MODEL`, `PROJMAN_LLM_TIMEOUT_SEC`, `PROJMAN_LLM_MAX_INPUT_CHARS`, `PROJMAN_LLM_MAX_OUTPUT_TOKENS`, `PROJMAN_LLM_TEMPERATURE`
+- Template: see `.env.example` (copy to `.env`; `.env` is gitignored)
+
+**Privacy / Safety**
+- Default: does **not** send full diff/source code.
+- Full diff sending requires explicit `--allow-send-diff`.
+- Payload is redacted best-effort and size-limited (may be truncated).
+
+**Examples**
+```bash
+# Preview payload locally without calling the LLM
+python -m src ai_review --dry-run
+
+# Review staged changes only
+python -m src ai_review --staged
+
+# Opt-in to send full diff content (privacy risk)
+python -m src ai_review --allow-send-diff
+
+# Write the review to a file (also prints to stdout)
+python -m src ai_review --out review.md
+```
+
+---
+
 ## Project Management Commands
 
 ### `project_new` — Create a project

--- a/docs/zh/user-guide/command-reference.md
+++ b/docs/zh/user-guide/command-reference.md
@@ -20,6 +20,44 @@ python -m src <命令> <参数> [选项]
 | `--help` | 显示帮助信息 | `python -m src --help` |
 | `--perf-analyze` | 启用性能分析 | `python -m src --perf-analyze po_apply proj1` |
 
+## AI 命令
+
+### `ai_review` - AI 辅助代码变更评审
+
+**状态**: ✅ 已实现
+
+**语法**:
+```bash
+python -m src ai_review [repo] [--staged] [--allow-send-diff] [--dry-run] [--out <path>] [--max-input-chars <n>]
+```
+
+**描述**: 对当前 git 变更生成 AI 评审建议。默认安全策略：不发送完整 diff/源码，仅发送 `git status --porcelain` 和 `git diff --stat`；只有显式指定 `--allow-send-diff` 才会发送完整 diff（可能会截断）。
+
+**配置方式**
+- 必需（除 `--dry-run` 外）：`PROJMAN_LLM_API_KEY`（或 `OPENAI_API_KEY`）
+- 可选：`PROJMAN_LLM_BASE_URL` / `PROJMAN_LLM_MODEL` / `PROJMAN_LLM_TIMEOUT_SEC` / `PROJMAN_LLM_MAX_INPUT_CHARS` / `PROJMAN_LLM_MAX_OUTPUT_TOKENS` / `PROJMAN_LLM_TEMPERATURE`
+- 模板：参考 `.env.example`（可复制为 `.env`；本仓库已默认忽略 `.env`）
+
+**隐私与安全**
+- 默认：不会发送完整 diff/源码。
+- 发送完整 diff 需要显式 `--allow-send-diff`。
+- 请求内容会进行 best-effort 脱敏与大小限制（可能截断）。
+
+**示例**:
+```bash
+# 只预览将发送给 LLM 的内容，不发起网络请求
+python -m src ai_review --dry-run
+
+# 只评审 staged 变更
+python -m src ai_review --staged
+
+# 显式允许发送完整 diff（隐私风险）
+python -m src ai_review --allow-send-diff
+
+# 输出到文件（同时也会打印到 stdout）
+python -m src ai_review --out review.md
+```
+
 ## 项目管理命令
 
 ### `project_new` - 创建新项目

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -30,6 +30,7 @@ import_module("src.plugins.project_builder")
 import_module("src.plugins.patch_override")
 import_module("src.plugins.doctor")
 import_module("src.plugins.snapshot")
+import_module("src.plugins.ai_review")
 
 
 # ===== Migration utility functions =====

--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -1,0 +1,1 @@
+"""AI/LLM integration helpers (optional features; safe-by-default)."""

--- a/src/ai/llm.py
+++ b/src/ai/llm.py
@@ -1,0 +1,173 @@
+"""Minimal LLM client abstraction (OpenAI-compatible HTTP API).
+
+Safety:
+- API keys are read from environment variables or a local .env file (never persisted).
+- Requests are size-limited and best-effort redacted before sending.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+from src.log_manager import log, redact_secrets
+
+
+class LLMError(RuntimeError):
+    """User-facing LLM error (safe to print; already redacted)."""
+
+
+def _parse_int(value: str, *, default: int) -> int:
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_float(value: str, *, default: float) -> float:
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _dotenv_load_if_present(dotenv_path: str) -> None:
+    """Load KEY=VALUE pairs from .env into os.environ if not already set.
+
+    This is intentionally minimal (no expansion, no export). It supports:
+    - blank lines and '#' comments
+    - quoted values with single/double quotes
+
+    It never overwrites existing env vars.
+    """
+    try:
+        if not os.path.exists(dotenv_path):
+            return
+        with open(dotenv_path, "r", encoding="utf-8") as f:
+            for raw in f:
+                line = raw.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                key = key.strip()
+                val = val.strip()
+                if not key:
+                    continue
+                if key in os.environ:
+                    continue
+                if len(val) >= 2 and ((val[0] == val[-1] == '"') or (val[0] == val[-1] == "'")):
+                    val = val[1:-1]
+                os.environ[key] = val
+    except (OSError, UnicodeError):
+        # Silent by design: .env is optional and should not break core flows.
+        return
+
+
+@dataclass(frozen=True)
+class LLMConfig:
+    """Configuration for OpenAI-compatible LLM calls."""
+
+    api_key: str
+    base_url: str
+    model: str
+    timeout_sec: int
+    max_input_chars: int
+    max_output_tokens: int
+    temperature: float
+
+
+def load_llm_config(*, root_path: str) -> Optional[LLMConfig]:
+    """Load LLM config from env and optional local .env.
+
+    Returns None if no API key is configured.
+    """
+    _dotenv_load_if_present(os.path.join(root_path, ".env"))
+
+    api_key = (os.environ.get("PROJMAN_LLM_API_KEY") or os.environ.get("OPENAI_API_KEY") or "").strip()
+    if not api_key:
+        return None
+
+    base_url = (os.environ.get("PROJMAN_LLM_BASE_URL") or "https://api.openai.com/v1").strip()
+    model = (os.environ.get("PROJMAN_LLM_MODEL") or "gpt-4o-mini").strip()
+    timeout_sec = _parse_int(os.environ.get("PROJMAN_LLM_TIMEOUT_SEC", ""), default=30)
+    max_input_chars = _parse_int(os.environ.get("PROJMAN_LLM_MAX_INPUT_CHARS", ""), default=12000)
+    max_output_tokens = _parse_int(os.environ.get("PROJMAN_LLM_MAX_OUTPUT_TOKENS", ""), default=700)
+    temperature = _parse_float(os.environ.get("PROJMAN_LLM_TEMPERATURE", ""), default=0.2)
+
+    return LLMConfig(
+        api_key=api_key,
+        base_url=base_url,
+        model=model,
+        timeout_sec=timeout_sec,
+        max_input_chars=max_input_chars,
+        max_output_tokens=max_output_tokens,
+        temperature=temperature,
+    )
+
+
+def _post_json(
+    *,
+    url: str,
+    headers: Dict[str, str],
+    payload: Dict[str, Any],
+    timeout_sec: int,
+) -> Tuple[int, str]:
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    req = urlrequest.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urlrequest.urlopen(req, timeout=timeout_sec) as resp:  # nosec - URL is user-configurable by design.
+            body = resp.read().decode("utf-8", errors="replace")
+            return int(getattr(resp, "status", 200)), body
+    except urlerror.HTTPError as exc:
+        try:
+            body = exc.read().decode("utf-8", errors="replace")
+        except Exception:  # pylint: disable=broad-exception-caught
+            body = ""
+        return int(getattr(exc, "code", 0) or 0), body
+    except urlerror.URLError as exc:
+        raise LLMError(f"LLM request failed: {exc}") from exc
+
+
+def openai_compatible_chat(
+    *,
+    cfg: LLMConfig,
+    messages: List[Dict[str, str]],
+) -> str:
+    """Call OpenAI-compatible Chat Completions API and return assistant text."""
+    url = cfg.base_url.rstrip("/") + "/chat/completions"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {cfg.api_key}",
+    }
+    payload: Dict[str, Any] = {
+        "model": cfg.model,
+        "messages": messages,
+        "temperature": cfg.temperature,
+        "max_tokens": cfg.max_output_tokens,
+    }
+
+    # Never log headers/payload (may contain sensitive data); only log safe metadata.
+    log.info("AI request: model=%s base_url=%s", cfg.model, cfg.base_url)
+
+    status, body = _post_json(url=url, headers=headers, payload=payload, timeout_sec=cfg.timeout_sec)
+    if status < 200 or status >= 300:
+        safe_body = redact_secrets(body)[:800]
+        raise LLMError(f"LLM request failed (HTTP {status}): {safe_body}")
+
+    try:
+        data = json.loads(body)
+        choices = data.get("choices") or []
+        if not choices:
+            raise LLMError("LLM response missing choices")
+        msg = choices[0].get("message") or {}
+        content = msg.get("content") or ""
+        return str(content).strip()
+    except (ValueError, TypeError) as exc:
+        safe_body = redact_secrets(body)[:800]
+        raise LLMError(f"LLM response parse failed: {safe_body}") from exc

--- a/src/plugins/ai_review.py
+++ b/src/plugins/ai_review.py
@@ -1,0 +1,177 @@
+"""AI-assisted review commands (optional; requires API key configuration)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.ai.llm import LLMError, load_llm_config, openai_compatible_chat
+from src.log_manager import log, redact_secrets
+from src.operations.registry import register
+
+
+def _run_git(args: List[str], *, cwd: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=False)
+
+
+def _ensure_git_repo(repo_dir: str) -> Tuple[bool, str]:
+    result = _run_git(["rev-parse", "--is-inside-work-tree"], cwd=repo_dir)
+    ok = result.returncode == 0 and result.stdout.strip().lower() == "true"
+    if ok:
+        return True, ""
+    msg = (result.stderr or result.stdout or "").strip()
+    if not msg:
+        msg = "not a git repository"
+    return False, msg
+
+
+def _git_text(repo_dir: str, *, staged: bool, diff: bool) -> Tuple[str, str, str]:
+    """Return (status_porcelain, diff_stat, diff_text_or_empty)."""
+    status = _run_git(["status", "--porcelain"], cwd=repo_dir)
+    status_text = (status.stdout or "").strip()
+
+    stat_args = ["diff", "--stat", "--no-color"]
+    diff_args = ["diff", "--no-color"]
+    if staged:
+        stat_args.insert(1, "--cached")
+        diff_args.insert(1, "--cached")
+
+    stat = _run_git(stat_args, cwd=repo_dir)
+    stat_text = (stat.stdout or "").strip()
+
+    diff_text = ""
+    if diff:
+        d = _run_git(diff_args, cwd=repo_dir)
+        diff_text = (d.stdout or "").strip()
+    return status_text, stat_text, diff_text
+
+
+def _truncate(text: str, *, limit: int) -> Tuple[str, bool]:
+    if limit <= 0 or len(text) <= limit:
+        return text, False
+    return text[:limit] + "\n[TRUNCATED]\n", True
+
+
+def _truthy(val: Any) -> bool:
+    if isinstance(val, bool):
+        return val
+    if val is None:
+        return False
+    text = str(val).strip().lower()
+    return text in {"1", "true", "yes", "y", "on"}
+
+
+def _to_int(val: Any, *, default: int) -> int:
+    if isinstance(val, int):
+        return val
+    try:
+        return int(str(val).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+@register(
+    "ai_review",
+    needs_projects=False,
+    needs_repositories=False,
+    desc="AI-assisted review of git changes (requires API key).",
+)
+def ai_review(
+    env: Dict[str, Any],
+    projects_info: Dict[str, Any],
+    repo: str = ".",
+    staged: bool = False,
+    allow_send_diff: bool = False,
+    out: str = "",
+    dry_run: bool = False,
+    max_input_chars: int = 0,
+) -> bool:
+    """
+    Generate an AI-assisted review for the current git changes.
+
+    repo (str): Path to a git repository to review (default: current directory).
+    staged (bool): Review staged changes only (`git diff --cached`).
+    allow_send_diff (bool): Opt-in: send full diff content to the LLM (privacy risk).
+    out (str): Optional output file path to write the review (also prints to stdout).
+    dry_run (bool): Do not call the LLM; print the (redacted, truncated) payload that would be sent.
+    max_input_chars (int): Override input size limit (defaults to env PROJMAN_LLM_MAX_INPUT_CHARS).
+    """
+
+    _ = projects_info
+
+    staged = _truthy(staged)
+    allow_send_diff = _truthy(allow_send_diff)
+    dry_run = _truthy(dry_run)
+    max_input_chars = _to_int(max_input_chars, default=0)
+
+    root_path = env.get("root_path") or os.getcwd()
+    repo_dir = repo
+    if not os.path.isabs(repo_dir):
+        repo_dir = os.path.join(root_path, repo_dir)
+    repo_dir = os.path.abspath(repo_dir)
+
+    ok, err = _ensure_git_repo(repo_dir)
+    if not ok:
+        print(f"Error: {err}")
+        return False
+
+    status_text, stat_text, diff_text = _git_text(repo_dir, staged=staged, diff=allow_send_diff)
+
+    # Minimal-by-default: only send stat + file list unless explicitly opted-in for full diff.
+    payload_parts: List[str] = []
+    payload_parts.append("## Git status (porcelain)")
+    payload_parts.append(status_text or "(clean)")
+    payload_parts.append("")
+    payload_parts.append("## Git diff --stat")
+    payload_parts.append(stat_text or "(no changes)")
+    if allow_send_diff:
+        payload_parts.append("")
+        payload_parts.append("## Git diff (full; may be truncated)")
+        payload_parts.append(diff_text or "(empty)")
+
+    payload = "\n".join(payload_parts)
+    payload = redact_secrets(payload)
+
+    cfg = load_llm_config(root_path=repo_dir)
+    limit = max_input_chars or (cfg.max_input_chars if cfg else 12000)
+    payload, truncated = _truncate(payload, limit=limit)
+
+    if dry_run:
+        print(payload)
+        if truncated:
+            log.warning("AI dry-run payload truncated to %d chars (override with --max-input-chars).", limit)
+        return True
+
+    if cfg is None:
+        print(
+            "AI is disabled: set PROJMAN_LLM_API_KEY (or OPENAI_API_KEY). "
+            "Optional: PROJMAN_LLM_BASE_URL / PROJMAN_LLM_MODEL."
+        )
+        return False
+
+    system = (
+        "You are a staff-level software engineer. Review the given git change summary and optionally diff.\n"
+        "Output a concise review with: summary, risks (security/correctness/performance), and suggested tests.\n"
+        "If the input is only --stat (no diff), be explicit about uncertainty."
+    )
+    user = "Review the following changes.\n" "Privacy note: do not ask for more code unless necessary.\n\n" f"{payload}"
+    messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+
+    try:
+        review = openai_compatible_chat(cfg=cfg, messages=messages)
+    except LLMError as exc:
+        print(f"Error: {exc}")
+        return False
+
+    if out:
+        try:
+            with open(out, "w", encoding="utf-8") as f:
+                f.write(review)
+                f.write("\n")
+        except OSError as exc:
+            print(f"Error: failed to write output: {exc}")
+            return False
+
+    print(review)
+    return True

--- a/tests/whitebox/plugins/test_ai_review.py
+++ b/tests/whitebox/plugins/test_ai_review.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+
+def _init_git_repo(repo_dir: Path) -> None:
+    subprocess.run(["git", "init"], cwd=str(repo_dir), check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=str(repo_dir), check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=str(repo_dir), check=True)
+
+    (repo_dir / "a.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "a.txt"], cwd=str(repo_dir), check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=str(repo_dir), check=True)
+
+
+def test_ai_review_dry_run_no_key(tmp_path: Path, capsys, monkeypatch) -> None:
+    from src.plugins.ai_review import ai_review
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    _init_git_repo(repo_dir)
+
+    # Create a working tree change
+    (repo_dir / "a.txt").write_text("base\nchange\n", encoding="utf-8")
+
+    # Ensure no ambient key is used
+    monkeypatch.delenv("PROJMAN_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    env: Dict[str, Any] = {"root_path": str(repo_dir), "projects_path": str(repo_dir / "projects")}
+    ok = ai_review(env, {}, dry_run=True)
+    assert ok is True
+
+    out = capsys.readouterr().out
+    assert "## Git diff --stat" in out
+    assert "a.txt" in out
+    assert "## Git diff (full" not in out
+
+
+def test_ai_review_missing_key_errors(tmp_path: Path, capsys, monkeypatch) -> None:
+    from src.plugins.ai_review import ai_review
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    _init_git_repo(repo_dir)
+
+    (repo_dir / "a.txt").write_text("base\nchange\n", encoding="utf-8")
+
+    monkeypatch.delenv("PROJMAN_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    env: Dict[str, Any] = {"root_path": str(repo_dir), "projects_path": str(repo_dir / "projects")}
+    ok = ai_review(env, {}, dry_run=False)
+    assert ok is False
+    assert "AI is disabled" in capsys.readouterr().out
+
+
+def test_ai_review_mock_provider_happy_path(tmp_path: Path, capsys, monkeypatch) -> None:
+    from src.ai import llm as llm_mod
+    from src.plugins.ai_review import ai_review
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    _init_git_repo(repo_dir)
+    (repo_dir / "a.txt").write_text("base\nchange\n", encoding="utf-8")
+
+    monkeypatch.setenv("PROJMAN_LLM_API_KEY", "dummy")
+    monkeypatch.setenv("PROJMAN_LLM_BASE_URL", "https://example.test/v1")
+    monkeypatch.setenv("PROJMAN_LLM_MODEL", "test-model")
+
+    captured = {}
+
+    def _fake_post_json(*, url: str, headers: Dict[str, str], payload: Dict[str, Any], timeout_sec: int):
+        _ = (url, headers, timeout_sec)
+        captured["payload"] = payload
+        return 200, json.dumps({"choices": [{"message": {"content": "OK REVIEW"}}]})
+
+    monkeypatch.setattr(llm_mod, "_post_json", _fake_post_json)
+
+    env: Dict[str, Any] = {"root_path": str(repo_dir), "projects_path": str(repo_dir / "projects")}
+    ok = ai_review(env, {}, dry_run=False)
+    assert ok is True
+
+    out = capsys.readouterr().out
+    assert "OK REVIEW" in out
+
+    # Default behavior: do not send full diff unless explicitly opted in.
+    msgs = captured["payload"]["messages"]
+    assert "## Git diff (full" not in msgs[1]["content"]


### PR DESCRIPTION
Closes #45

## What
- Added `ai_review`: AI-assisted review of local git changes (safe-by-default).
- Added minimal OpenAI-compatible LLM client abstraction + `.env.example` (API key via env or local .env; never persisted).
- Added unit tests with mocked provider; updated docs and command reference (en/zh).

## Privacy / Safety
- Default behavior does NOT send full diff/source code; only `git status --porcelain` + `git diff --stat`.
- Full diff sending requires explicit `--allow-send-diff`.
- Payload is redacted best-effort and size-limited (truncation).

## Verification
- `make lint`
- `make test`

## Rollback
- `git revert 5c779a9`