### PR TITLE
feat(ai): add ai_explain for logs/CI

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -122,6 +122,7 @@ pyinstaller \
     --hidden-import=src.plugins.doctor \
     --hidden-import=src.plugins.snapshot \
     --hidden-import=src.plugins.ai_review \
+    --hidden-import=src.plugins.ai_explain \
     --hidden-import=src.plugins.mcp_server \
     --hidden-import=src.plugins.po_plugins \
     --hidden-import=src.operations.registry \

--- a/docs/en/user-guide/command-reference.md
+++ b/docs/en/user-guide/command-reference.md
@@ -112,6 +112,37 @@ python -m src ai_review --allow-send-diff
 python -m src ai_review --out review.md
 ```
 
+### `ai_explain` — AI-assisted explanation of logs/CI failures
+
+**Status**: ✅ Implemented
+
+**Syntax**
+```bash
+python -m src ai_explain [path] [--tail-lines <n>] [--dry-run] [--out <path>] [--max-input-chars <n>] [--question <text>]
+```
+
+**Description**: Explain a failure by analyzing the tail of a log file. By default it reads `.cache/latest.log` under the repo root and sends a redacted, size-limited excerpt to the LLM.
+
+**Configuration**
+- Required (unless `--dry-run`): `PROJMAN_LLM_API_KEY` (or `OPENAI_API_KEY`)
+- Optional: same as `ai_review` (see `.env.example`)
+
+**Privacy / Safety**
+- Sends only a tail excerpt (default: last 200 lines).
+- Payload is redacted best-effort and size-limited (may be truncated).
+
+**Examples**
+```bash
+# Preview what would be sent (no network)
+python -m src ai_explain --dry-run
+
+# Explain the latest log symlink
+python -m src ai_explain .cache/latest.log
+
+# Use a bigger tail window and include a question
+python -m src ai_explain build.log --tail-lines 400 --question "Why did this fail and what should I try next?"
+```
+
 ---
 
 ## MCP Commands

--- a/docs/test_cases_en.md
+++ b/docs/test_cases_en.md
@@ -273,6 +273,8 @@ Notes:
 | AI-001 | AI | `ai_review --dry-run` works without API key | Run inside any git repo with local changes | 1. Run `python -m src ai_review --dry-run`.<br>2. Observe stdout. | Prints a redacted, size-limited payload (status + `git diff --stat`) without calling the LLM; exits 0. | P1 | DX |
 | AI-002 | AI | `ai_review` errors cleanly when key missing | No `PROJMAN_LLM_API_KEY` / `OPENAI_API_KEY` configured | 1. Run `python -m src ai_review`.<br>2. Observe output and exit code. | Exits non-zero with a clear \"AI is disabled\" message; other commands remain unaffected. | P1 | Negative |
 | AI-003 | AI | Full diff sending is explicit opt-in | API key configured | 1. Run `python -m src ai_review --allow-send-diff`.<br>2. Observe review output. | Full diff is included in the request (may be truncated); output includes review and suggests tests; no secrets are printed. | P2 | Privacy |
+| AI-004 | AI | `ai_explain --dry-run` works without API key | Any command has been run to create logs | 1. Run `python -m src --help`.<br>2. Run `python -m src ai_explain --dry-run`.<br>3. Observe stdout. | Prints a redacted, size-limited payload (tail excerpt from `.cache/latest.log`) without calling the LLM; exits 0. | P1 | DX |
+| AI-005 | AI | `ai_explain` errors cleanly when key missing | No `PROJMAN_LLM_API_KEY` / `OPENAI_API_KEY` configured | 1. Run `python -m src ai_explain`.<br>2. Observe output and exit code. | Exits non-zero with a clear \"AI is disabled\" message; other commands remain unaffected. | P1 | Negative |
 
 ## 15. MCP Server (src/plugins/mcp_server.py)
 

--- a/docs/zh/user-guide/command-reference.md
+++ b/docs/zh/user-guide/command-reference.md
@@ -58,6 +58,37 @@ python -m src ai_review --allow-send-diff
 python -m src ai_review --out review.md
 ```
 
+### `ai_explain` - AI 辅助日志/CI 失败分析
+
+**状态**: ✅ 已实现
+
+**语法**:
+```bash
+python -m src ai_explain [path] [--tail-lines <n>] [--dry-run] [--out <path>] [--max-input-chars <n>] [--question <text>]
+```
+
+**描述**: 读取日志文件尾部片段并交给 LLM 进行分析，输出可能的根因、下一步建议与验证方式。默认读取仓库根目录下的 `.cache/latest.log`，并对请求内容进行 best-effort 脱敏与大小限制。
+
+**配置方式**
+- 必需（除 `--dry-run` 外）：`PROJMAN_LLM_API_KEY`（或 `OPENAI_API_KEY`）
+- 可选：与 `ai_review` 相同（参考 `.env.example`）
+
+**隐私与安全**
+- 仅发送尾部片段（默认最后 200 行）。
+- 请求内容会进行 best-effort 脱敏与大小限制（可能截断）。
+
+**示例**:
+```bash
+# 只预览将发送给 LLM 的内容，不发起网络请求
+python -m src ai_explain --dry-run
+
+# 分析最新日志
+python -m src ai_explain .cache/latest.log
+
+# 扩大尾部窗口并附带问题
+python -m src ai_explain build.log --tail-lines 400 --question "为什么失败？下一步怎么排查？"
+```
+
 ## MCP 命令
 
 ### `mcp_server` - MCP stdio server（只读工具）

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -31,6 +31,7 @@ import_module("src.plugins.patch_override")
 import_module("src.plugins.doctor")
 import_module("src.plugins.snapshot")
 import_module("src.plugins.ai_review")
+import_module("src.plugins.ai_explain")
 import_module("src.plugins.mcp_server")
 
 

--- a/src/plugins/ai_explain.py
+++ b/src/plugins/ai_explain.py
@@ -1,0 +1,173 @@
+"""AI-assisted debugging for logs / CI failures (optional; requires API key configuration)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional, Tuple
+
+from src.ai.llm import LLMError, load_llm_config, openai_compatible_chat
+from src.log_manager import log, redact_secrets
+from src.operations.registry import register
+
+
+def _truthy(val: Any) -> bool:
+    if isinstance(val, bool):
+        return val
+    if val is None:
+        return False
+    text = str(val).strip().lower()
+    return text in {"1", "true", "yes", "y", "on"}
+
+
+def _to_int(val: Any, *, default: int) -> int:
+    if isinstance(val, int):
+        return val
+    try:
+        return int(str(val).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _truncate(text: str, *, limit: int) -> Tuple[str, bool]:
+    if limit <= 0 or len(text) <= limit:
+        return text, False
+    return text[:limit] + "\n[TRUNCATED]\n", True
+
+
+def _read_file_tail(
+    path: str,
+    *,
+    tail_lines: int,
+    max_bytes: int,
+) -> Tuple[str, bool]:
+    """Read a tail excerpt from a text file.
+
+    Returns: (text, truncated_by_bytes).
+    """
+    with open(path, "rb") as f:
+        f.seek(0, os.SEEK_END)
+        size = int(f.tell())
+        read_size = min(size, int(max_bytes))
+        f.seek(max(0, size - read_size), os.SEEK_SET)
+        data = f.read(read_size)
+
+    truncated = read_size < size
+    text = data.decode("utf-8", errors="replace")
+    lines = text.replace("\r\n", "\n").replace("\r", "\n").splitlines()
+    if tail_lines > 0:
+        lines = lines[-int(tail_lines) :]
+    out = "\n".join(lines).strip()
+    return out, truncated
+
+
+@register(
+    "ai_explain",
+    needs_projects=False,
+    needs_repositories=False,
+    desc="AI-assisted explanation of logs/CI failures (requires API key).",
+)
+def ai_explain(
+    env: Dict[str, Any],
+    projects_info: Dict[str, Any],
+    path: str = "",
+    tail_lines: int = 200,
+    out: str = "",
+    dry_run: bool = False,
+    max_input_chars: int = 0,
+    question: str = "",
+) -> bool:
+    """
+    Explain logs / CI failures using an LLM.
+
+    path (str): Path to a log file to analyze. Default: `.cache/latest.log` under repo root.
+    tail_lines (int): How many lines from the end to include (default: 200).
+    out (str): Optional output file path to write the analysis (also prints to stdout).
+    dry_run (bool): Do not call the LLM; print the (redacted, truncated) payload that would be sent.
+    max_input_chars (int): Override input size limit (defaults to env PROJMAN_LLM_MAX_INPUT_CHARS).
+    question (str): Optional user question to guide the analysis.
+    """
+
+    _ = projects_info
+
+    dry_run = _truthy(dry_run)
+    tail_lines = _to_int(tail_lines, default=200)
+    max_input_chars = _to_int(max_input_chars, default=0)
+    question = str(question or "").strip()
+
+    root_path = env.get("root_path") or os.getcwd()
+    log_path = path.strip() if isinstance(path, str) else ""
+    if not log_path:
+        log_path = os.path.join(root_path, ".cache", "latest.log")
+    if not os.path.isabs(log_path):
+        log_path = os.path.abspath(os.path.join(root_path, log_path))
+
+    if not os.path.isfile(log_path):
+        print(f"Error: log file not found: {log_path}")
+        return False
+
+    try:
+        excerpt, truncated_by_bytes = _read_file_tail(log_path, tail_lines=tail_lines, max_bytes=600_000)
+    except OSError as exc:
+        print(f"Error: failed to read log: {exc}")
+        return False
+
+    excerpt = redact_secrets(excerpt)
+
+    cfg = load_llm_config(root_path=root_path)
+    limit = max_input_chars or (cfg.max_input_chars if cfg else 12000)
+    excerpt, truncated = _truncate(excerpt, limit=limit)
+
+    payload = "\n".join(
+        [
+            f"# Log excerpt ({os.path.relpath(log_path, root_path)})",
+            f"- tail_lines={tail_lines}",
+            f"- truncated_by_bytes={truncated_by_bytes}",
+            f"- truncated_by_chars={truncated}",
+            "",
+            excerpt or "(empty)",
+        ]
+    )
+
+    if dry_run:
+        print(payload)
+        if truncated:
+            log.warning("AI dry-run payload truncated to %d chars (override with --max-input-chars).", limit)
+        return True
+
+    if cfg is None:
+        print(
+            "AI is disabled: set PROJMAN_LLM_API_KEY (or OPENAI_API_KEY). "
+            "Optional: PROJMAN_LLM_BASE_URL / PROJMAN_LLM_MODEL."
+        )
+        return False
+
+    system = (
+        "You are a staff-level software engineer. Analyze the given ProjectManager logs/CI excerpt.\n"
+        "Output: (1) likely root cause(s), (2) what to try next (commands/checks), (3) how to confirm the fix.\n"
+        "Be explicit about uncertainty when evidence is insufficient. Do not request more code unless necessary."
+    )
+    user = "Explain the following failure.\n\n"
+    if question:
+        user += f"User question: {question}\n\n"
+    user += payload
+    messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+
+    try:
+        analysis = openai_compatible_chat(cfg=cfg, messages=messages)
+    except LLMError as exc:
+        print(f"Error: {exc}")
+        return False
+
+    analysis = redact_secrets(analysis)
+
+    if out:
+        try:
+            with open(out, "w", encoding="utf-8") as f:
+                f.write(analysis)
+                f.write("\n")
+        except OSError as exc:
+            print(f"Error: failed to write output: {exc}")
+            return False
+
+    print(analysis)
+    return True

--- a/tests/whitebox/plugins/test_ai_explain.py
+++ b/tests/whitebox/plugins/test_ai_explain.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def test_ai_explain_dry_run_redacts_without_key(tmp_path: Path, capsys, monkeypatch) -> None:
+    from src.plugins.ai_explain import ai_explain
+
+    (tmp_path / ".cache").mkdir()
+    token = "ghp_" + ("A" * 36)
+    (tmp_path / ".cache" / "latest.log").write_text(f"start\n{token}\nBearer xyz\nend\n", encoding="utf-8")
+
+    monkeypatch.delenv("PROJMAN_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    env: Dict[str, Any] = {"root_path": str(tmp_path), "projects_path": str(tmp_path / "projects")}
+    ok = ai_explain(env, {}, dry_run=True)
+    assert ok is True
+
+    out = capsys.readouterr().out
+    assert "# Log excerpt" in out
+    assert token not in out
+    assert "ghp_***" in out
+    assert "Bearer ***" in out
+
+
+def test_ai_explain_missing_key_errors(tmp_path: Path, capsys, monkeypatch) -> None:
+    from src.plugins.ai_explain import ai_explain
+
+    (tmp_path / ".cache").mkdir()
+    (tmp_path / ".cache" / "latest.log").write_text("x\n", encoding="utf-8")
+
+    monkeypatch.delenv("PROJMAN_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    env: Dict[str, Any] = {"root_path": str(tmp_path), "projects_path": str(tmp_path / "projects")}
+    ok = ai_explain(env, {}, dry_run=False)
+    assert ok is False
+    assert "AI is disabled" in capsys.readouterr().out
+
+
+def test_ai_explain_mock_provider_happy_path(tmp_path: Path, capsys, monkeypatch) -> None:
+    from src.ai import llm as llm_mod
+    from src.plugins.ai_explain import ai_explain
+
+    (tmp_path / ".cache").mkdir()
+    (tmp_path / ".cache" / "latest.log").write_text("boom\n", encoding="utf-8")
+
+    monkeypatch.setenv("PROJMAN_LLM_API_KEY", "dummy")
+    monkeypatch.setenv("PROJMAN_LLM_BASE_URL", "https://example.test/v1")
+    monkeypatch.setenv("PROJMAN_LLM_MODEL", "test-model")
+
+    def _fake_post_json(*, url: str, headers: Dict[str, str], payload: Dict[str, Any], timeout_sec: int):
+        _ = (url, headers, timeout_sec)
+        assert payload["messages"][1]["content"].startswith("Explain the following failure.")
+        return 200, json.dumps({"choices": [{"message": {"content": "OK EXPLAIN"}}]})
+
+    monkeypatch.setattr(llm_mod, "_post_json", _fake_post_json)
+
+    env: Dict[str, Any] = {"root_path": str(tmp_path), "projects_path": str(tmp_path / "projects")}
+    ok = ai_explain(env, {}, dry_run=False)
+    assert ok is True
+    assert "OK EXPLAIN" in capsys.readouterr().out


### PR DESCRIPTION
Closes #47

Adds `ai_explain` to analyze the tail of a log file (default: `.cache/latest.log`) and ask an LLM for likely root cause + next steps.

Safety:
- Default sends only a tail excerpt (last 200 lines) and redacts token-like patterns.
- `--dry-run` works without an API key.

Docs + tests included.
