### PR TITLE
feat(ai): embeddings client + config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,11 @@ PROJMAN_LLM_API_KEY=
 # OpenAI-compatible endpoint + model
 PROJMAN_LLM_BASE_URL=https://api.openai.com/v1
 PROJMAN_LLM_MODEL=gpt-4o-mini
+# Optional: embeddings model (for semantic search / indexing)
+PROJMAN_LLM_EMBEDDING_MODEL=text-embedding-3-small
 #
 # Safety / limits
 PROJMAN_LLM_TIMEOUT_SEC=30
 PROJMAN_LLM_MAX_INPUT_CHARS=12000
 PROJMAN_LLM_MAX_OUTPUT_TOKENS=700
 PROJMAN_LLM_TEMPERATURE=0.2
-

--- a/tests/whitebox/test_llm_embeddings.py
+++ b/tests/whitebox/test_llm_embeddings.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def _cfg():
+    from src.ai.llm import LLMConfig
+
+    return LLMConfig(
+        api_key="dummy",
+        base_url="https://example.test/v1",
+        model="chat-model",
+        embedding_model="embed-model",
+        timeout_sec=10,
+        max_input_chars=12000,
+        max_output_tokens=700,
+        temperature=0.2,
+    )
+
+
+def test_openai_compatible_embeddings_happy_path(monkeypatch) -> None:
+    from src.ai import llm as llm_mod
+    from src.ai.llm import openai_compatible_embeddings
+
+    def _fake_post_json(*, url: str, headers, payload, timeout_sec: int):
+        _ = (url, headers, timeout_sec)
+        assert payload["model"] == "embed-model"
+        assert payload["input"] == ["a", "b"]
+        body = {"data": [{"index": 0, "embedding": [0.1, 0.2]}, {"index": 1, "embedding": [0.3, 0.4]}]}
+        return 200, json.dumps(body)
+
+    monkeypatch.setattr(llm_mod, "_post_json", _fake_post_json)
+
+    out = openai_compatible_embeddings(cfg=_cfg(), inputs=["a", "b"])
+    assert out == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_openai_compatible_embeddings_http_error(monkeypatch) -> None:
+    from src.ai import llm as llm_mod
+    from src.ai.llm import LLMError, openai_compatible_embeddings
+
+    def _fake_post_json(*, url: str, headers, payload, timeout_sec: int):
+        _ = (url, headers, payload, timeout_sec)
+        return 401, '{"error":"nope"}'
+
+    monkeypatch.setattr(llm_mod, "_post_json", _fake_post_json)
+
+    with pytest.raises(LLMError) as exc:
+        openai_compatible_embeddings(cfg=_cfg(), inputs=["x"])
+    assert "HTTP 401" in str(exc.value)
+
+
+def test_openai_compatible_embeddings_missing_index(monkeypatch) -> None:
+    from src.ai import llm as llm_mod
+    from src.ai.llm import LLMError, openai_compatible_embeddings
+
+    def _fake_post_json(*, url: str, headers, payload, timeout_sec: int):
+        _ = (url, headers, payload, timeout_sec)
+        body = {"data": [{"index": 0, "embedding": [0.1, 0.2]}]}
+        return 200, json.dumps(body)
+
+    monkeypatch.setattr(llm_mod, "_post_json", _fake_post_json)
+
+    with pytest.raises(LLMError):
+        openai_compatible_embeddings(cfg=_cfg(), inputs=["a", "b"])


### PR DESCRIPTION
Closes #56

Adds an OpenAI-compatible embeddings client in `src/ai/llm.py`.

- New env var: `PROJMAN_LLM_EMBEDDING_MODEL` (documented in `.env.example`)
- New helper: `openai_compatible_embeddings()` (no payload logging)
- Unit tests cover happy path and error paths (mocked HTTP)
