### PR TITLE
feat(ai): ai_test generator MVP (NF-0011.A)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -124,6 +124,7 @@ pyinstaller \
     --hidden-import=src.plugins.ai_review \
     --hidden-import=src.plugins.ai_explain \
     --hidden-import=src.plugins.ai_docs \
+    --hidden-import=src.plugins.ai_test \
     --hidden-import=src.plugins.ai_semantic_search \
     --hidden-import=src.plugins.mcp_server \
     --hidden-import=src.plugins.po_plugins \

--- a/docs/en/user-guide/command-reference.md
+++ b/docs/en/user-guide/command-reference.md
@@ -174,6 +174,37 @@ python -m src ai_docs mcp_server --lang en
 python -m src ai_docs mcp_server --lang zh
 ```
 
+### `ai_test` — AI-assisted pytest scaffold generation
+
+**Status**: ✅ Implemented
+
+**Syntax**
+```bash
+python -m src ai_test <path> [--symbol <name>] [--allow-send-code] [--dry-run] [--max-input-chars <n>]
+```
+
+**Description**: Generate pytest unit test scaffolds for a selected Python file (and optional symbol). Outputs a single Python test file content to stdout.
+
+**Configuration**
+- Required (unless `--dry-run`): `PROJMAN_LLM_API_KEY` (or `OPENAI_API_KEY`)
+- Optional: `PROJMAN_LLM_BASE_URL`, `PROJMAN_LLM_MODEL`, `PROJMAN_LLM_TIMEOUT_SEC`, `PROJMAN_LLM_MAX_INPUT_CHARS`, `PROJMAN_LLM_MAX_OUTPUT_TOKENS`, `PROJMAN_LLM_TEMPERATURE`
+- Template: see `.env.example` (copy to `.env`; `.env` is gitignored)
+
+**Privacy / Safety**
+- Default: refuses to send source code.
+- Sending source code requires explicit `--allow-send-code` (privacy risk).
+- Only the selected file is sent (redacted best-effort + size-limited; may be truncated).
+- No file is written in the MVP; redirect stdout if you want to save the output.
+
+**Examples**
+```bash
+# Preview payload (no network)
+python -m src ai_test src/plugins/patch_override.py --symbol parse_po_config --dry-run
+
+# Generate tests (requires API key + explicit opt-in to send code)
+python -m src ai_test src/plugins/patch_override.py --symbol parse_po_config --allow-send-code
+```
+
 ### `ai_index` — Build semantic search index (embeddings)
 
 **Status**: ✅ Implemented

--- a/docs/test_cases_en.md
+++ b/docs/test_cases_en.md
@@ -281,6 +281,9 @@ Notes:
 | AI-009 | AI | `ai_index` errors cleanly when key missing | No `PROJMAN_LLM_API_KEY` / `OPENAI_API_KEY` configured | 1. Run `python -m src ai_index`.<br>2. Observe output and exit code. | Exits non-zero with a clear \"AI is disabled\" message; no index file is written. | P2 | Negative |
 | AI-010 | AI | Indexing source code requires explicit opt-in | API key configured | 1. Run `python -m src ai_index`.<br>2. Inspect printed plan or resulting index metadata.<br>3. Run `python -m src ai_index --allow-send-code --dry-run`.<br>4. Compare file list. | Default indexes docs only; source code files under `src/` / `tests/` appear only when `--allow-send-code` is set. | P2 | Privacy |
 | AI-011 | AI | `ai_search` errors cleanly when key missing | No `PROJMAN_LLM_API_KEY` / `OPENAI_API_KEY` configured | 1. Run `python -m src ai_search --query \"where is MCP implemented\"`.<br>2. Observe output and exit code. | Exits non-zero with a clear \"AI is disabled\" message; other commands remain unaffected. | P2 | Negative |
+| AI-012 | AI | `ai_test --dry-run` works without API key | Repo contains target `.py` file | 1. Run `python -m src ai_test src/utils.py --dry-run`.<br>2. Observe stdout. | Prints a redacted, size-limited payload without calling the LLM; exits 0. | P2 | DX |
+| AI-013 | AI | `ai_test` errors cleanly when key missing | No `PROJMAN_LLM_API_KEY` / `OPENAI_API_KEY` configured | 1. Run `python -m src ai_test src/utils.py --allow-send-code`.<br>2. Observe output and exit code. | Exits non-zero with a clear \"AI is disabled\" message; other commands remain unaffected. | P2 | Negative |
+| AI-014 | AI | `ai_test` requires explicit `--allow-send-code` | API key configured | 1. Run `python -m src ai_test src/utils.py`.<br>2. Observe output and exit code. | Exits non-zero with a clear message requiring `--allow-send-code` (privacy safety); does not call the LLM. | P2 | Privacy |
 
 ## 15. MCP Server (src/plugins/mcp_server.py)
 

--- a/docs/zh/user-guide/command-reference.md
+++ b/docs/zh/user-guide/command-reference.md
@@ -120,6 +120,37 @@ python -m src ai_docs mcp_server --lang en
 python -m src ai_docs mcp_server --lang zh
 ```
 
+### `ai_test` - AI 辅助单测脚手架生成（pytest）
+
+**状态**: ✅ 已实现
+
+**语法**:
+```bash
+python -m src ai_test <path> [--symbol <name>] [--allow-send-code] [--dry-run] [--max-input-chars <n>]
+```
+
+**描述**: 为指定的 Python 文件（可选聚焦到某个函数/类）生成 pytest 单测脚手架。MVP 仅输出到 stdout（不写入文件）。
+
+**配置方式**
+- 必需（除 `--dry-run` 外）：`PROJMAN_LLM_API_KEY`（或 `OPENAI_API_KEY`）
+- 可选：`PROJMAN_LLM_BASE_URL` / `PROJMAN_LLM_MODEL` / `PROJMAN_LLM_TIMEOUT_SEC` / `PROJMAN_LLM_MAX_INPUT_CHARS` / `PROJMAN_LLM_MAX_OUTPUT_TOKENS` / `PROJMAN_LLM_TEMPERATURE`
+- 模板：参考 `.env.example`（可复制为 `.env`；本仓库已默认忽略 `.env`）
+
+**隐私与安全**
+- 默认拒绝发送源码。
+- 发送源码必须显式指定 `--allow-send-code`（隐私风险）。
+- 仅发送用户选择的单个文件（best-effort 脱敏 + 大小限制；可能截断）。
+- MVP 不会写文件，如需保存可自行重定向 stdout。
+
+**示例**:
+```bash
+# 只预览将发送给 LLM 的内容，不发起网络请求
+python -m src ai_test src/plugins/patch_override.py --symbol parse_po_config --dry-run
+
+# 生成测试（需要 API key + 显式允许发送源码）
+python -m src ai_test src/plugins/patch_override.py --symbol parse_po_config --allow-send-code
+```
+
 ### `ai_index` - 构建语义检索索引（Embeddings）
 
 **状态**: ✅ 已实现

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -33,6 +33,7 @@ import_module("src.plugins.snapshot")
 import_module("src.plugins.ai_review")
 import_module("src.plugins.ai_explain")
 import_module("src.plugins.ai_docs")
+import_module("src.plugins.ai_test")
 import_module("src.plugins.ai_semantic_search")
 import_module("src.plugins.mcp_server")
 

--- a/src/plugins/ai_test.py
+++ b/src/plugins/ai_test.py
@@ -1,0 +1,198 @@
+"""AI-assisted unit test scaffold generator (optional; requires API key configuration).
+
+Safety:
+- Default off (requires API key).
+- Requires explicit `--allow-send-code` to send source code to the LLM.
+- Sends only the selected file (never the whole repo by default).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Tuple
+
+from src.ai.llm import LLMError, load_llm_config, openai_compatible_chat
+from src.log_manager import log, redact_secrets
+from src.operations.registry import register
+
+
+def _truthy(val: Any) -> bool:
+    if isinstance(val, bool):
+        return val
+    if val is None:
+        return False
+    text = str(val).strip().lower()
+    return text in {"1", "true", "yes", "y", "on"}
+
+
+def _to_int(val: Any, *, default: int) -> int:
+    if isinstance(val, int):
+        return val
+    try:
+        return int(str(val).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _truncate(text: str, *, limit: int) -> Tuple[str, bool]:
+    if limit <= 0 or len(text) <= limit:
+        return text, False
+    return text[:limit] + "\n[TRUNCATED]\n", True
+
+
+def _safe_relpath(path: str) -> str:
+    path = str(path or "").strip().replace("\\", "/")
+    if not path:
+        return ""
+    if path.startswith("/") or path.startswith("//"):
+        return ""
+    if ":" in path.split("/")[0]:
+        return ""
+    path = os.path.normpath(path).replace("\\", "/")
+    if path in {"", ".", "/"}:
+        return ""
+    if path.startswith("..") or "/.." in path:
+        return ""
+    return path
+
+
+def _read_text_file(abs_path: str, *, max_bytes: int) -> Tuple[bool, str]:
+    try:
+        if os.path.getsize(abs_path) > max_bytes:
+            return False, f"file too large (> {max_bytes} bytes)"
+        with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
+            return True, f.read()
+    except OSError as exc:
+        return False, str(exc)
+
+
+@register(
+    "ai_test",
+    needs_projects=False,
+    needs_repositories=False,
+    desc="AI-assisted pytest scaffold generation (requires API key).",
+)
+def ai_test(
+    env: Dict[str, Any],
+    projects_info: Dict[str, Any],
+    path: str,
+    symbol: str = "",
+    allow_send_code: bool = False,
+    dry_run: bool = False,
+    max_input_chars: int = 0,
+) -> bool:
+    """
+    Generate pytest unit test scaffolds for a selected Python file (and optional symbol).
+
+    path (str): Target Python file path (relative to repo root).
+    symbol (str): Optional function/class name to focus on.
+    allow_send_code (bool): Opt-in: send selected source code to the LLM (privacy risk).
+    dry_run (bool): Do not call the LLM; print the (redacted, truncated) payload that would be sent.
+    max_input_chars (int): Override input size limit (defaults to env PROJMAN_LLM_MAX_INPUT_CHARS).
+    """
+
+    _ = projects_info
+
+    dry_run = _truthy(dry_run)
+    allow_send_code = _truthy(allow_send_code)
+    max_input_chars = _to_int(max_input_chars, default=0)
+
+    root_path = env.get("root_path") or os.getcwd()
+
+    # Only allow paths within the workspace root.
+    rel = _safe_relpath(path)
+    if not rel:
+        # Also allow absolute paths that are still within root_path.
+        abs_candidate = os.path.abspath(path)
+        root_abs = os.path.abspath(root_path)
+        rel_from_root = os.path.relpath(abs_candidate, root_abs).replace("\\", "/")
+        rel_from_root_safe = _safe_relpath(rel_from_root)
+        if not rel_from_root_safe:
+            print("Error: path is invalid or unsafe (must be a workspace-relative path).")
+            return False
+        rel = rel_from_root_safe
+
+    abs_path = os.path.abspath(os.path.join(root_path, rel))
+    if not os.path.isfile(abs_path):
+        print(f"Error: file not found: {rel}")
+        return False
+    if not rel.endswith(".py"):
+        print("Error: only .py files are supported for ai_test.")
+        return False
+
+    # Prepare payload (redacted + size-limited).
+    source_note = (
+        "Source is NOT included by default. To include it, pass --allow-send-code (privacy risk)."
+        if not allow_send_code
+        else "Source included (opt-in)."
+    )
+
+    src_text = ""
+    if allow_send_code:
+        ok, content_or_err = _read_text_file(abs_path, max_bytes=200_000)
+        if not ok:
+            print(f"Error: failed to read source: {content_or_err}")
+            return False
+        src_text = redact_secrets(content_or_err)
+
+    parts: List[str] = []
+    parts.append("# Target")
+    parts.append(f"path: {rel}")
+    if symbol:
+        parts.append(f"symbol: {redact_secrets(symbol)}")
+    parts.append("")
+    parts.append("# Privacy / Data Boundary")
+    parts.append(source_note)
+    parts.append("Generate tests without requiring network access.")
+    parts.append("")
+    parts.append("# Source (redacted; may be truncated)")
+    parts.append(src_text if src_text else "(omitted)")
+    payload = "\n".join(parts)
+
+    cfg = load_llm_config(root_path=root_path)
+    limit = max_input_chars or (cfg.max_input_chars if cfg else 12000)
+    payload, truncated = _truncate(payload, limit=limit)
+
+    if dry_run:
+        print(payload)
+        if truncated:
+            log.warning("AI dry-run payload truncated to %d chars (override with --max-input-chars).", limit)
+        return True
+
+    if cfg is None:
+        print(
+            "AI is disabled: set PROJMAN_LLM_API_KEY (or OPENAI_API_KEY). "
+            "Optional: PROJMAN_LLM_BASE_URL / PROJMAN_LLM_MODEL."
+        )
+        return False
+
+    if not allow_send_code:
+        print("Error: refusing to send source code by default. Re-run with --allow-send-code to opt in.")
+        return False
+
+    system = (
+        "You are a staff-level Python engineer.\n"
+        "Generate pytest unit tests for the given source file and optional symbol.\n"
+        "Constraints:\n"
+        "- Output ONLY valid Python code (no markdown, no commentary).\n"
+        "- Tests must be deterministic and not require network access.\n"
+        "- Prefer unit tests with minimal mocking.\n"
+        "- If you need assumptions, encode them as TODO comments in the test file.\n"
+    )
+    user = (
+        "Create pytest tests for the target.\n"
+        "Return a single Python file content (suitable for tests/).\n\n"
+        f"{payload}"
+    )
+
+    messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+    try:
+        out = openai_compatible_chat(cfg=cfg, messages=messages)
+    except LLMError as exc:
+        print(f"Error: {exc}")
+        return False
+
+    # Never log the generated content; only log safe metadata.
+    log.info("ai_test generated output for %s (len=%d)", rel, len(out))
+    print(out.strip() + "\n")
+    return True

--- a/tests/whitebox/plugins/test_ai_test.py
+++ b/tests/whitebox/plugins/test_ai_test.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def test_ai_test_dry_run_no_key(tmp_path: Path, capsys, monkeypatch) -> None:
+    from src.plugins.ai_test import ai_test
+
+    (tmp_path / "mod.py").write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+
+    monkeypatch.delenv("PROJMAN_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    env: Dict[str, Any] = {"root_path": str(tmp_path), "projects_path": str(tmp_path / "projects")}
+    ok = ai_test(env, {}, "mod.py", dry_run=True)
+    assert ok is True
+
+    out = capsys.readouterr().out
+    assert "path: mod.py" in out
+    assert "Source (redacted" in out
+
+
+def test_ai_test_missing_key_errors(tmp_path: Path, capsys, monkeypatch) -> None:
+    from src.plugins.ai_test import ai_test
+
+    (tmp_path / "mod.py").write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+
+    monkeypatch.delenv("PROJMAN_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    env: Dict[str, Any] = {"root_path": str(tmp_path), "projects_path": str(tmp_path / "projects")}
+    ok = ai_test(env, {}, "mod.py", allow_send_code=True, dry_run=False)
+    assert ok is False
+    assert "AI is disabled" in capsys.readouterr().out
+
+
+def test_ai_test_requires_allow_send_code(tmp_path: Path, capsys, monkeypatch) -> None:
+    from src.plugins.ai_test import ai_test
+
+    (tmp_path / "mod.py").write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+
+    monkeypatch.setenv("PROJMAN_LLM_API_KEY", "dummy")
+    monkeypatch.setenv("PROJMAN_LLM_BASE_URL", "https://example.test/v1")
+    monkeypatch.setenv("PROJMAN_LLM_MODEL", "test-model")
+
+    env: Dict[str, Any] = {"root_path": str(tmp_path), "projects_path": str(tmp_path / "projects")}
+    ok = ai_test(env, {}, "mod.py", allow_send_code=False, dry_run=False)
+    assert ok is False
+    assert "--allow-send-code" in capsys.readouterr().out
+
+
+def test_ai_test_mock_provider_happy_path(tmp_path: Path, capsys, monkeypatch) -> None:
+    from src.ai import llm as llm_mod
+    from src.plugins.ai_test import ai_test
+
+    token = "ghp_" + ("A" * 36)
+    (tmp_path / "mod.py").write_text(f"def add(a, b):\n    return a + b  # {token}\n", encoding="utf-8")
+
+    monkeypatch.setenv("PROJMAN_LLM_API_KEY", "dummy")
+    monkeypatch.setenv("PROJMAN_LLM_BASE_URL", "https://example.test/v1")
+    monkeypatch.setenv("PROJMAN_LLM_MODEL", "test-model")
+
+    def _fake_post_json(*, url: str, headers: Dict[str, str], payload: Dict[str, Any], timeout_sec: int):
+        _ = (headers, timeout_sec)
+        assert url.endswith("/chat/completions")
+        # Raw token must not be sent.
+        assert token not in json.dumps(payload)
+        return 200, json.dumps({"choices": [{"message": {"content": "def test_smoke():\\n    assert True\\n"}}]})
+
+    monkeypatch.setattr(llm_mod, "_post_json", _fake_post_json)
+
+    env: Dict[str, Any] = {"root_path": str(tmp_path), "projects_path": str(tmp_path / "projects")}
+    ok = ai_test(env, {}, "mod.py", allow_send_code=True, dry_run=False)
+    assert ok is True
+    assert "def test_smoke" in capsys.readouterr().out


### PR DESCRIPTION
Closes #58\n\nWhat\n- Add ai_test command: generate pytest test scaffolds for a selected .py file and optional symbol.\n- Safe-by-default: requires --allow-send-code to send the selected file to the LLM; --dry-run works without key.\n\nVerification\n- make format, make lint, make test