### PR TITLE
feat(ai): safe --out for ai_test (NF-0011.B)

### DIFF
--- a/docs/en/user-guide/command-reference.md
+++ b/docs/en/user-guide/command-reference.md
@@ -180,7 +180,7 @@ python -m src ai_docs mcp_server --lang zh
 
 **Syntax**
 ```bash
-python -m src ai_test <path> [--symbol <name>] [--allow-send-code] [--dry-run] [--max-input-chars <n>]
+python -m src ai_test <path> [--symbol <name>] [--allow-send-code] [--out <path>] [--dry-run] [--max-input-chars <n>]
 ```
 
 **Description**: Generate pytest unit test scaffolds for a selected Python file (and optional symbol). Outputs a single Python test file content to stdout.
@@ -194,7 +194,7 @@ python -m src ai_test <path> [--symbol <name>] [--allow-send-code] [--dry-run] [
 - Default: refuses to send source code.
 - Sending source code requires explicit `--allow-send-code` (privacy risk).
 - Only the selected file is sent (redacted best-effort + size-limited; may be truncated).
-- No file is written in the MVP; redirect stdout if you want to save the output.
+- Default writes no files; use `--out` to write within the workspace (unsafe paths are rejected).
 
 **Examples**
 ```bash
@@ -203,6 +203,9 @@ python -m src ai_test src/plugins/patch_override.py --symbol parse_po_config --d
 
 # Generate tests (requires API key + explicit opt-in to send code)
 python -m src ai_test src/plugins/patch_override.py --symbol parse_po_config --allow-send-code
+
+# Write to a file under tests/ (also prints to stdout)
+python -m src ai_test src/plugins/patch_override.py --symbol parse_po_config --allow-send-code --out tests/test_patch_override_ai.py
 ```
 
 ### `ai_index` — Build semantic search index (embeddings)

--- a/docs/test_cases_en.md
+++ b/docs/test_cases_en.md
@@ -284,6 +284,7 @@ Notes:
 | AI-012 | AI | `ai_test --dry-run` works without API key | Repo contains target `.py` file | 1. Run `python -m src ai_test src/utils.py --dry-run`.<br>2. Observe stdout. | Prints a redacted, size-limited payload without calling the LLM; exits 0. | P2 | DX |
 | AI-013 | AI | `ai_test` errors cleanly when key missing | No `PROJMAN_LLM_API_KEY` / `OPENAI_API_KEY` configured | 1. Run `python -m src ai_test src/utils.py --allow-send-code`.<br>2. Observe output and exit code. | Exits non-zero with a clear \"AI is disabled\" message; other commands remain unaffected. | P2 | Negative |
 | AI-014 | AI | `ai_test` requires explicit `--allow-send-code` | API key configured | 1. Run `python -m src ai_test src/utils.py`.<br>2. Observe output and exit code. | Exits non-zero with a clear message requiring `--allow-send-code` (privacy safety); does not call the LLM. | P2 | Privacy |
+| AI-015 | AI | `ai_test --out` only allows safe workspace paths | API key configured | 1. Run `python -m src ai_test src/utils.py --allow-send-code --out tests/test_ai_out.py`.<br>2. Run `python -m src ai_test src/utils.py --allow-send-code --out ../bad.py`. | Safe path writes file under `tests/` and prints a pytest verification hint; unsafe path is rejected and writes nothing. | P2 | Safety |
 
 ## 15. MCP Server (src/plugins/mcp_server.py)
 

--- a/docs/zh/user-guide/command-reference.md
+++ b/docs/zh/user-guide/command-reference.md
@@ -126,7 +126,7 @@ python -m src ai_docs mcp_server --lang zh
 
 **语法**:
 ```bash
-python -m src ai_test <path> [--symbol <name>] [--allow-send-code] [--dry-run] [--max-input-chars <n>]
+python -m src ai_test <path> [--symbol <name>] [--allow-send-code] [--out <path>] [--dry-run] [--max-input-chars <n>]
 ```
 
 **描述**: 为指定的 Python 文件（可选聚焦到某个函数/类）生成 pytest 单测脚手架。MVP 仅输出到 stdout（不写入文件）。
@@ -140,7 +140,7 @@ python -m src ai_test <path> [--symbol <name>] [--allow-send-code] [--dry-run] [
 - 默认拒绝发送源码。
 - 发送源码必须显式指定 `--allow-send-code`（隐私风险）。
 - 仅发送用户选择的单个文件（best-effort 脱敏 + 大小限制；可能截断）。
-- MVP 不会写文件，如需保存可自行重定向 stdout。
+- 默认不写文件；如需落盘请使用 `--out`（仅允许写入 workspace 内部，危险路径会被拒绝）。
 
 **示例**:
 ```bash
@@ -149,6 +149,9 @@ python -m src ai_test src/plugins/patch_override.py --symbol parse_po_config --d
 
 # 生成测试（需要 API key + 显式允许发送源码）
 python -m src ai_test src/plugins/patch_override.py --symbol parse_po_config --allow-send-code
+
+# 写入 tests/ 下的文件（同时也会打印到 stdout）
+python -m src ai_test src/plugins/patch_override.py --symbol parse_po_config --allow-send-code --out tests/test_patch_override_ai.py
 ```
 
 ### `ai_index` - 构建语义检索索引（Embeddings）

--- a/tests/whitebox/plugins/test_ai_test.py
+++ b/tests/whitebox/plugins/test_ai_test.py
@@ -75,3 +75,40 @@ def test_ai_test_mock_provider_happy_path(tmp_path: Path, capsys, monkeypatch) -
     ok = ai_test(env, {}, "mod.py", allow_send_code=True, dry_run=False)
     assert ok is True
     assert "def test_smoke" in capsys.readouterr().out
+
+
+def test_ai_test_out_path_unsafe_rejected(tmp_path: Path, capsys) -> None:
+    from src.plugins.ai_test import ai_test
+
+    (tmp_path / "mod.py").write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+
+    env: Dict[str, Any] = {"root_path": str(tmp_path), "projects_path": str(tmp_path / "projects")}
+    ok = ai_test(env, {}, "mod.py", out="../bad.py", dry_run=True)
+    assert ok is False
+    assert "out path is invalid" in capsys.readouterr().out
+
+
+def test_ai_test_writes_out_with_mock_provider(tmp_path: Path, capsys, monkeypatch) -> None:
+    from src.ai import llm as llm_mod
+    from src.plugins.ai_test import ai_test
+
+    (tmp_path / "mod.py").write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+
+    monkeypatch.setenv("PROJMAN_LLM_API_KEY", "dummy")
+    monkeypatch.setenv("PROJMAN_LLM_BASE_URL", "https://example.test/v1")
+    monkeypatch.setenv("PROJMAN_LLM_MODEL", "test-model")
+
+    def _fake_post_json(*, url: str, headers: Dict[str, str], payload: Dict[str, Any], timeout_sec: int):
+        _ = (url, headers, payload, timeout_sec)
+        return 200, json.dumps({"choices": [{"message": {"content": "def test_smoke():\\n    assert True\\n"}}]})
+
+    monkeypatch.setattr(llm_mod, "_post_json", _fake_post_json)
+
+    env: Dict[str, Any] = {"root_path": str(tmp_path), "projects_path": str(tmp_path / "projects")}
+    ok = ai_test(env, {}, "mod.py", allow_send_code=True, out="tests/test_generated.py")
+    assert ok is True
+
+    out_path = tmp_path / "tests" / "test_generated.py"
+    assert out_path.exists()
+    assert "def test_smoke" in out_path.read_text(encoding="utf-8")
+    assert "Wrote: tests/test_generated.py" in capsys.readouterr().out


### PR DESCRIPTION
Closes #57\n\nWhat\n- Add --out to ai_test to write generated tests to a safe workspace-relative path (rejects unsafe paths).\n- Print a pytest verification hint after writing.\n\nVerification\n- make format, make lint, make test