### PR TITLE
ci: publish beta prerelease on push to master

### DIFF
--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -1,0 +1,227 @@
+name: Publish Beta Prerelease
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y patchelf binutils git
+
+      - name: Build project (beta channel)
+        shell: bash
+        env:
+          PROJMAN_RELEASE_CHANNEL: beta
+        run: bash build.sh
+
+      - name: Run tests
+        shell: bash
+        run: bash -lc "source venv/bin/activate && pytest"
+
+      - name: Run lint
+        shell: bash
+        run: bash -lc "source venv/bin/activate && make lint"
+
+  build-binaries:
+    name: build-binaries (beta) (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y patchelf binutils
+
+      - name: Build project (beta channel)
+        shell: bash
+        env:
+          PROJMAN_RELEASE_CHANNEL: beta
+        run: bash build.sh
+
+      - name: Compute artifact metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          uname_s="$(uname -s 2>/dev/null || echo unknown)"
+          case "$uname_s" in
+            Linux) platform="linux" ;;
+            Darwin) platform="macos" ;;
+            MINGW*|MSYS*|CYGWIN*|Windows_NT) platform="windows" ;;
+            *) platform="unknown" ;;
+          esac
+          arch="$(uname -m 2>/dev/null || echo unknown)"
+          case "$arch" in
+            x86_64|amd64) arch="x86_64" ;;
+            aarch64|arm64) arch="arm64" ;;
+          esac
+          echo "platform=$platform" >> "$GITHUB_OUTPUT"
+          echo "arch=$arch" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare release binary
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f out/projman_binary_path.txt ]; then
+            binary_path="$(cat out/projman_binary_path.txt)"
+          else
+            binary_path=""
+          fi
+
+          if [ -n "$binary_path" ] && [ -e "$binary_path" ]; then
+            ext=""
+            case "$binary_path" in
+              *.exe) ext=".exe" ;;
+              *.pkg) ext=".pkg" ;;
+            esac
+            out_file="out/release_upload/projman-${{ steps.meta.outputs.platform }}-${{ steps.meta.outputs.arch }}${ext}"
+            mkdir -p out/release_upload
+            cp -L "$binary_path" "$out_file"
+            echo "upload_path=$out_file" >> "$GITHUB_OUTPUT"
+          else
+            echo "Warning: beta binary path unavailable, falling back to upload full out/ directory."
+            find out -maxdepth 5 \( -type f -o -type l \) | sed 's#^#  - #' || true
+            echo "upload_path=out" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: projman-${{ steps.meta.outputs.platform }}-${{ steps.meta.outputs.arch }}
+          if-no-files-found: error
+          path: ${{ steps.package.outputs.upload_path }}
+
+  prerelease:
+    runs-on: ubuntu-latest
+    needs: build-binaries
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          copied=0
+          while IFS= read -r file; do
+            name="$(basename "$file")"
+            cp "$file" "release/$name"
+            sha256sum "release/$name" > "release/$name.sha256"
+            copied=$((copied + 1))
+          done < <(find artifacts/projman-* -type f -name 'projman-*' | sort)
+
+          if [ "$copied" -eq 0 ]; then
+            echo "No beta release binaries collected from artifacts/" >&2
+            find artifacts -maxdepth 3 -type f | sed 's#^#  - #' >&2 || true
+            exit 1
+          fi
+
+      - name: Compute beta tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          short="${GITHUB_SHA:0:7}"
+          # Unique per run attempt; does not match stable tag trigger (v*).
+          echo "tag=beta-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${short}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve base version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          ver="$(
+            python - <<'PY'
+          import tomllib
+          from pathlib import Path
+          data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          print(data["project"]["version"])
+          PY
+          )"
+          echo "version=${ver}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate prerelease notes
+        shell: bash
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          cat > release/RELEASE_NOTES.md <<EOF
+          # ProjectManager Beta ${VERSION}
+
+          - Tag: \`${TAG}\`
+          - Commit SHA: \`${GITHUB_SHA:0:12}\`
+          - Channel: beta (GitHub prerelease)
+
+          ## Install / Update
+
+          - If you already have projman installed:
+            - \`projman update --beta\`
+          - If you want to pin to stable releases:
+            - \`projman update --stable\`
+
+          ## Assets & Checksums
+          EOF
+
+          for binary in release/projman-*; do
+            [ -f "$binary" ] || continue
+            sha_file="${binary}.sha256"
+            sha_value=""
+            if [ -f "$sha_file" ]; then
+              sha_value="$(awk '{print $1}' "$sha_file" | head -n1)"
+            fi
+            if [ -n "$sha_value" ]; then
+              echo "- \`$(basename "$binary")\` — \`${sha_value}\`" >> release/RELEASE_NOTES.md
+            else
+              echo "- \`$(basename "$binary")\`" >> release/RELEASE_NOTES.md
+            fi
+          done
+
+      - name: Create Beta Prerelease
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          target_commitish: ${{ github.sha }}
+          name: Beta ${{ steps.version.outputs.version }} (${{ github.sha }})
+          prerelease: true
+          files: |
+            release/projman-*
+          body_path: release/RELEASE_NOTES.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Summary
- Add a dedicated workflow to publish a GitHub **beta prerelease** automatically on each push to `master`.
- Beta binaries are built with `PROJMAN_RELEASE_CHANNEL=beta`, so `projman --version` includes the `+beta` marker in packaged artifacts.
- Publish release assets as `projman-<platform>-<arch>(.exe)` plus `.sha256` checksums.
- Does **not** publish to PyPI and does **not** publish stable docker images.

## Notes
- The beta workflow uses tags like `beta-<run_id>-<attempt>-<sha>` and therefore will not trigger the stable release workflow (which is tag `v*`).
- Stable releases remain manual via `release.sh` (tag `vX.Y.Z`).

Closes #65.
