### PR TITLE
chore: bump version to 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.0.17"
+version = "0.1.0"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]


### PR DESCRIPTION
## Summary
- bump package version from 0.0.17 to 0.1.0

## Tests
- make format
- python -m pytest tests/blackbox/test_cli.py::test_cli_002_version_matches_pyproject tests/blackbox/test_cli.py::test_cli_002a_version_no_projects_dir_no_warnings tests/blackbox/test_cli_blackbox_en.py::test_cli_version_matches_pyproject tests/blackbox/test_cli_safe_mode_blackbox_en.py::test_safe_mode_version_works tests/blackbox/test_utils_log_profiler.py::test_util_001_version_matches_pyproject tests/blackbox/test_utils_log_profiler.py::test_util_002_version_fallback tests/whitebox/test_utils.py::TestGetVersion
- python -m src --version


