### PR TITLE
ci: require same-repo main PR sources

### DIFF
--- a/.github/workflows/validate-main-pr-source.yml
+++ b/.github/workflows/validate-main-pr-source.yml
@@ -22,8 +22,15 @@ jobs:
         shell: bash
         env:
           HEAD_BRANCH: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::PRs targeting main must come from branches in $BASE_REPO, got $HEAD_REPO."
+            exit 1
+          fi
+
           case "$HEAD_BRANCH" in
             dev|bug/*|fix/*)
               echo "Allowed source branch: $HEAD_BRANCH"


### PR DESCRIPTION
## Summary
- require PRs targeting main to come from branches in this repository
- keep allowed main sources limited to dev, bug/*, and fix/*

## Tests
- make format
- YAML parse for .github/workflows/*.yml
- git diff --check
