### PR TITLE
ci: remove legacy main branch prefixes

### DIFF
--- a/.github/workflows/validate-main-pr-source.yml
+++ b/.github/workflows/validate-main-pr-source.yml
@@ -32,11 +32,11 @@ jobs:
           fi
 
           case "$HEAD_BRANCH" in
-            dev|bug/*|fix/*)
+            dev|bug/*)
               echo "Allowed source branch: $HEAD_BRANCH"
               ;;
             *)
-              echo "::error::PRs targeting main must come from dev, bug/*, or fix/* branches."
+              echo "::error::PRs targeting main must come from dev or bug/* branches."
               exit 1
               ;;
           esac


### PR DESCRIPTION
## Summary
- update main PR source validation to allow only dev and bug/*
- remove legacy fix/* allowance

## Tests
- make format
- YAML parse for .github/workflows/*.yml
- git diff --check
