### PR TITLE
ci: adopt main-only branch flow

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: ["main", "dev"]
+    branches: ["main"]
     paths:
       - ".github/workflows/mypy.yml"
       - "**.py"
@@ -14,7 +14,7 @@ on:
       - "mypy_baseline.json"
       - "scripts/mypy_ci.py"
   pull_request:
-    branches: ["main", "dev"]
+    branches: ["main"]
     paths:
       - ".github/workflows/mypy.yml"
       - "**.py"

--- a/.github/workflows/pr-prerelease.yml
+++ b/.github/workflows/pr-prerelease.yml
@@ -1,18 +1,31 @@
-name: Publish Beta Prerelease
+name: PR Prerelease
 
 on:
-  push:
+  pull_request:
     branches:
-      - dev
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   workflow_dispatch:
 
 permissions:
-  contents: write
-  actions: read
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-22.04
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (
+          startsWith(github.head_ref, 'feature/') ||
+          startsWith(github.head_ref, 'bug/')
+        )
+      )
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -47,14 +60,14 @@ jobs:
       - name: Upload package artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: projman-python-package
+          name: projman-pr-${{ github.event.pull_request.number || github.run_id }}-python-package
           if-no-files-found: error
           path: |
             out/package/*.whl
             out/package/*.tar.gz
 
   build-binaries:
-    name: build-binaries (beta) (${{ matrix.os }})
+    name: build-binaries (prerelease) (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: test
     strategy:
@@ -114,7 +127,7 @@ jobs:
           echo "platform=$platform" >> "$GITHUB_OUTPUT"
           echo "arch=$arch" >> "$GITHUB_OUTPUT"
 
-      - name: Prepare release binary
+      - name: Prepare prerelease binary
         id: package
         shell: bash
         run: |
@@ -131,12 +144,12 @@ jobs:
               *.exe) ext=".exe" ;;
               *.pkg) ext=".pkg" ;;
             esac
-            out_file="out/release_upload/projman-${{ steps.meta.outputs.platform }}-${{ steps.meta.outputs.arch }}${ext}"
-            mkdir -p out/release_upload
+            out_file="out/prerelease_upload/projman-${{ steps.meta.outputs.platform }}-${{ steps.meta.outputs.arch }}${ext}"
+            mkdir -p out/prerelease_upload
             cp -L "$binary_path" "$out_file"
             echo "upload_path=$out_file" >> "$GITHUB_OUTPUT"
           else
-            echo "Warning: beta binary path unavailable, falling back to upload full out/ directory."
+            echo "Warning: prerelease binary path unavailable, falling back to upload full out/ directory."
             find out -maxdepth 5 \( -type f -o -type l \) | sed 's#^#  - #' || true
             echo "upload_path=out" >> "$GITHUB_OUTPUT"
           fi
@@ -144,113 +157,6 @@ jobs:
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: projman-${{ steps.meta.outputs.platform }}-${{ steps.meta.outputs.arch }}
+          name: projman-pr-${{ github.event.pull_request.number || github.run_id }}-${{ steps.meta.outputs.platform }}-${{ steps.meta.outputs.arch }}
           if-no-files-found: error
           path: ${{ steps.package.outputs.upload_path }}
-
-  prerelease:
-    runs-on: ubuntu-latest
-    needs: build-binaries
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Create release assets
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p release
-          copied=0
-          while IFS= read -r file; do
-            name="$(basename "$file")"
-            cp "$file" "release/$name"
-            sha256sum "release/$name" > "release/$name.sha256"
-            copied=$((copied + 1))
-          done < <(find artifacts -type f \( -name 'projman-*' -o -name 'multi_project_manager-*' \) | sort)
-
-          if [ "$copied" -eq 0 ]; then
-            echo "No beta release binaries collected from artifacts/" >&2
-            find artifacts -maxdepth 3 -type f | sed 's#^#  - #' >&2 || true
-            exit 1
-          fi
-
-      - name: Compute beta tag
-        id: tag
-        shell: bash
-        run: |
-          set -euo pipefail
-          short="${GITHUB_SHA:0:7}"
-          # Unique per run attempt; does not match stable tag trigger (v*).
-          echo "tag=beta-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${short}" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve base version
-        id: version
-        shell: bash
-        run: |
-          set -euo pipefail
-          ver="$(
-            python - <<'PY'
-          import tomllib
-          from pathlib import Path
-          data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-          print(data["project"]["version"])
-          PY
-          )"
-          echo "version=${ver}" >> "$GITHUB_OUTPUT"
-
-      - name: Generate prerelease notes
-        shell: bash
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-          cat > release/RELEASE_NOTES.md <<EOF
-          # ProjectManager Beta ${VERSION}
-
-          - Tag: \`${TAG}\`
-          - Commit SHA: \`${GITHUB_SHA:0:12}\`
-          - Channel: beta (GitHub prerelease)
-
-          ## Install / Update
-
-          - If you already have projman installed:
-            - \`projman update --beta\`
-          - If you want to pin to stable releases:
-            - \`projman update --stable\`
-
-          ## Assets & Checksums
-          EOF
-
-          for binary in release/projman-*; do
-            [ -f "$binary" ] || continue
-            sha_file="${binary}.sha256"
-            sha_value=""
-            if [ -f "$sha_file" ]; then
-              sha_value="$(awk '{print $1}' "$sha_file" | head -n1)"
-            fi
-            if [ -n "$sha_value" ]; then
-              echo "- \`$(basename "$binary")\` — \`${sha_value}\`" >> release/RELEASE_NOTES.md
-            else
-              echo "- \`$(basename "$binary")\`" >> release/RELEASE_NOTES.md
-            fi
-          done
-
-      - name: Create Beta Prerelease
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          target_commitish: ${{ github.sha }}
-          name: Beta ${{ steps.version.outputs.version }} (${{ github.sha }})
-          prerelease: true
-          files: |
-            release/projman-*
-          body_path: release/RELEASE_NOTES.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,14 +4,14 @@ permissions:
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
     paths:
       - '**.py'
       - 'requirements.txt'
       - 'pyproject.toml'
       - '.pylintrc'
   pull_request:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
     paths:
       - '**.py'
       - 'requirements.txt'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,7 +5,7 @@ name: Python application
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
     paths:
       - '.github/workflows/python-app.yml'
       - '**.py'
@@ -16,7 +16,7 @@ on:
       - 'install.sh'
       - 'uninstall.sh'
   pull_request:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
     paths:
       - '.github/workflows/python-app.yml'
       - '**.py'

--- a/.github/workflows/validate-main-pr-source.yml
+++ b/.github/workflows/validate-main-pr-source.yml
@@ -18,7 +18,7 @@ jobs:
     name: validate-main-source-branch
     runs-on: ubuntu-latest
     steps:
-      - name: Require dev or bug source branch
+      - name: Require feature or bug source branch
         shell: bash
         env:
           HEAD_BRANCH: ${{ github.head_ref }}
@@ -32,11 +32,11 @@ jobs:
           fi
 
           case "$HEAD_BRANCH" in
-            dev|bug/*)
+            feature/*|bug/*)
               echo "Allowed source branch: $HEAD_BRANCH"
               ;;
             *)
-              echo "::error::PRs targeting main must come from dev or bug/* branches."
+              echo "::error::PRs targeting main must come from feature/* or bug/* branches."
               exit 1
               ;;
           esac


### PR DESCRIPTION
Switch the repository to the main-only branch flow.\n\nChanges:\n- Allow PRs into main only from same-repo feature/* or bug/* branches.\n- Remove dev from CI triggers.\n- Replace dev push beta release with PR prerelease artifacts.\n- Keep version updates on main release changes only; no version bump in feature/bug branches.\n\nLocal checks:\n-  make format\n- YAML workflow parse\n- git diff --check

