### PR TITLE
ci: allow ci branches into main

### DIFF
--- a/.github/workflows/validate-main-pr-source.yml
+++ b/.github/workflows/validate-main-pr-source.yml
@@ -18,7 +18,7 @@ jobs:
     name: validate-main-source-branch
     runs-on: ubuntu-latest
     steps:
-      - name: Require feature or bug source branch
+      - name: Require feature, bug, or ci source branch
         shell: bash
         env:
           HEAD_BRANCH: ${{ github.head_ref }}
@@ -32,11 +32,11 @@ jobs:
           fi
 
           case "$HEAD_BRANCH" in
-            feature/*|bug/*)
+            feature/*|bug/*|ci/*)
               echo "Allowed source branch: $HEAD_BRANCH"
               ;;
             *)
-              echo "::error::PRs targeting main must come from feature/* or bug/* branches."
+              echo "::error::PRs targeting main must come from feature/*, bug/*, or ci/* branches."
               exit 1
               ;;
           esac


### PR DESCRIPTION
Allow same-repo ci/* branches to open PRs into main while keeping the rebase and no-merge-commit checks.\n\nAllowed main PR sources after this change:\n- feature/*\n- bug/*\n- ci/*\n\nLocal checks:\n-  make format\n- YAML workflow parse\n- Local equivalent rebased branch check\n- git diff --check

