### PR TITLE
ci: enable main source validation for 0.1.0

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
     paths:
       - ".github/workflows/mypy.yml"
       - "**.py"
@@ -14,7 +14,7 @@ on:
       - "mypy_baseline.json"
       - "scripts/mypy_ci.py"
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
     paths:
       - ".github/workflows/mypy.yml"
       - "**.py"
@@ -39,4 +39,3 @@ jobs:
       - name: Run mypy (ratcheted baseline)
         run: |
           make typecheck
-

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,14 +4,14 @@ permissions:
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
     paths:
       - '**.py'
       - 'requirements.txt'
       - 'pyproject.toml'
       - '.pylintrc'
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
     paths:
       - '**.py'
       - 'requirements.txt'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,7 +5,7 @@ name: Python application
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
     paths:
       - '.github/workflows/python-app.yml'
       - '**.py'
@@ -16,7 +16,7 @@ on:
       - 'install.sh'
       - 'uninstall.sh'
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
     paths:
       - '.github/workflows/python-app.yml'
       - '**.py'

--- a/.github/workflows/validate-main-pr-source.yml
+++ b/.github/workflows/validate-main-pr-source.yml
@@ -1,0 +1,77 @@
+name: Validate Main PR Source
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+permissions:
+  contents: read
+
+jobs:
+  validate-main-source-branch:
+    name: validate-main-source-branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require same-repo feature, bug, or ci source branch
+        shell: bash
+        env:
+          HEAD_BRANCH: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::PRs targeting main must come from branches in $BASE_REPO, got $HEAD_REPO."
+            exit 1
+          fi
+
+          case "$HEAD_BRANCH" in
+            feature/*|bug/*|ci/*)
+              echo "Allowed source branch: $HEAD_BRANCH"
+              ;;
+            *)
+              echo "::error::PRs targeting main must come from feature/*, bug/*, or ci/* branches."
+              exit 1
+              ;;
+          esac
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Require rebased PR branch
+        shell: bash
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags --prune origin "+refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
+          base_ref="refs/remotes/origin/${BASE_BRANCH}"
+
+          actual_head="$(git rev-parse HEAD)"
+          if [ "$actual_head" != "$HEAD_SHA" ]; then
+            echo "::error::Checked out $actual_head, expected PR head $HEAD_SHA."
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$base_ref" HEAD; then
+            echo "::error::PR branch must be rebased on latest ${BASE_BRANCH}."
+            echo "::error::Run: git fetch origin && git rebase origin/${BASE_BRANCH}"
+            exit 1
+          fi
+
+          merge_count="$(git rev-list --merges --count "${base_ref}..HEAD")"
+          if [ "$merge_count" != "0" ]; then
+            echo "::error::PR branch contains merge commits after ${BASE_BRANCH}; rebase instead of merging ${BASE_BRANCH} into the branch."
+            git log --oneline --merges "${base_ref}..HEAD"
+            exit 1
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.0.17"
+version = "0.1.0"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]


### PR DESCRIPTION
Enable the main PR source validation workflow and bump the project version to 0.1.0.\n\nChanges:\n- Add validate-main-source-branch workflow for PRs into main.\n- Allow same-repo feature/*, bug/*, and ci/* branches only.\n- Require PR branches to be rebased on latest main and contain no merge commits after main.\n- Update Python application, Pylint, and mypy workflows from master to main triggers.\n- Bump pyproject.toml version to 0.1.0.\n\nLocal checks:\n-  make format\n- YAML workflow parse\n- Local equivalent rebased branch check\n- git diff --check\n-  make test

