### PR TITLE
chore: bump version and document release checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,10 @@ You are working in the `ProjectManager` repository - a Python CLI tool for multi
 4. After each module-level change (or after verifying a test suite passes), make a small commit and push it.
 5. Before each commit, run `make format` (black + isort).
 6. After each push, confirm GitHub Actions is green for the pushed commit SHA.
-7. Track work in the repo-root TODO note and delete completed TODO items:
+7. For changes intended to ship from `main`, bump `pyproject.toml` in the same PR.
+8. After merging a stable release PR to `main`, create and push the matching `vX.Y.Z` tag from the updated `main` commit.
+9. Do not consider release work complete until the publish workflow and published artifacts are verified.
+10. Track work in the repo-root TODO note and delete completed TODO items:
    - `./TODO.md`
 
 ## Code Organization
@@ -85,20 +88,42 @@ make check-all
 - `--version` includes short git commit hash when available.
 - Build metadata: `scripts/write_build_info.py` (used by `build.sh` and CI).
 - Version is in `pyproject.toml`.
+- Stable release tags must match `pyproject.toml` exactly: `pyproject.toml` version `X.Y.Z` -> tag `vX.Y.Z`.
+- Patch/bug releases increment the patch version, for example `0.1.0` -> `0.1.1`.
 
 ## CI/CD
 
 GitHub Actions workflows in `.github/workflows/`:
 - `python-app.yml`: Main test suite
 - `pylint.yml`: Linting
-- `publish-python.yml`: PyPI release
-- `publish-release.yml`: GitHub release
+- `publish-python.yml`: Manual PyPI release
+- `publish-release.yml`: Tag-based stable release, GitHub Release assets, PyPI publish, and Docker publish
+
+Stable release flow:
+```bash
+# After the release PR is merged and local main is synced:
+VERSION="$(python - <<'PY'
+import tomllib
+from pathlib import Path
+print(tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]["version"])
+PY
+)"
+git tag "v${VERSION}"
+git push origin "v${VERSION}"
+gh run list --repo wangguanran/ProjectManager --workflow publish-release.yml --limit 5
+gh run watch <run-id> --repo wangguanran/ProjectManager --exit-status
+gh release view "v${VERSION}" --repo wangguanran/ProjectManager
+```
+
+After publishing, verify the `publish-release.yml` run completed successfully and confirm:
+- the GitHub Release `vX.Y.Z` exists and has uploaded assets,
+- PyPI contains `multi-project-manager==X.Y.Z` or the workflow explicitly skipped upload because that version already exists,
+- Docker publish succeeded or any failure is documented before handoff.
 
 Check CI status after push:
 ```bash
 SHA="$(git rev-parse HEAD)"
 curl -sS -H "Accept: application/vnd.github+json" \
-  "https://api.github.com/repos/wangguanran/ProjectManager/actions/runs?per_page=30&branch=master" \
+  "https://api.github.com/repos/wangguanran/ProjectManager/actions/runs?per_page=30&branch=main" \
   | SHA="$SHA" python3 -c 'import os,sys,json; sha=os.environ["SHA"]; data=json.load(sys.stdin); runs=[r for r in data.get("workflow_runs",[]) if r.get("head_sha")==sha]; print([(r.get("name"),r.get("status"),r.get("conclusion")) for r in runs])'
 ```
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]


### PR DESCRIPTION
## Summary
- bump stable version to 0.1.1 for the merged patch override fix
- document the required stable release tag and post-publish verification flow in AGENTS.md
- fix the CI status example to query main instead of master

## Tests
- make format
- make test
