### PR TITLE
ci: automate release version bumps

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Bump the project version in pyproject.toml for release automation."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Tuple
+
+VERSION_PATTERN = re.compile(r'(?m)^(version\s*=\s*")(\d+)\.(\d+)\.(\d+)(")')
+Version = Tuple[int, int, int]
+
+
+def parse_version(text: str) -> Version:
+    """Return the project version tuple from pyproject.toml content."""
+    match = VERSION_PATTERN.search(text)
+    if not match:
+        raise ValueError("Unable to find project.version in pyproject.toml")
+    return tuple(int(part) for part in match.group(2, 3, 4))
+
+
+def bump_version(version: Version, part: str) -> Version:
+    """Bump a semantic version part and reset lower-order parts."""
+    major, minor, patch = version
+    if part == "major":
+        return major + 1, 0, 0
+    if part == "minor":
+        return major, minor + 1, 0
+    if part == "patch":
+        return major, minor, patch + 1
+    raise ValueError(f"Unsupported bump part: {part}")
+
+
+def format_version(version: Version) -> str:
+    """Render a version tuple as X.Y.Z."""
+    return ".".join(str(part) for part in version)
+
+
+def replace_version(text: str, version: Version) -> str:
+    """Replace the first project.version assignment in pyproject.toml content."""
+    replacement = rf"\g<1>{format_version(version)}\g<5>"
+    updated, count = VERSION_PATTERN.subn(replacement, text, count=1)
+    if count != 1:
+        raise ValueError("Unable to replace project.version in pyproject.toml")
+    return updated
+
+
+def read_file_from_ref(ref: str, filename: str) -> str:
+    """Read a file from a git ref."""
+    return subprocess.check_output(
+        ["git", "show", f"{ref}:{filename}"],
+        text=True,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def write_github_output(version: str) -> None:
+    """Expose the computed version to GitHub Actions when available."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a", encoding="utf-8") as output:
+        output.write(f"version={version}\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--file", default="pyproject.toml", help="Path to pyproject.toml")
+    parser.add_argument(
+        "--base-ref",
+        help="Git ref to read the base version from; defaults to the working tree file",
+    )
+    parser.add_argument(
+        "--part",
+        choices=("major", "minor", "patch"),
+        required=True,
+        help="Semantic version part to bump",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Update the working tree file with the computed version",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    version_file = Path(args.file)
+    base_text = (
+        read_file_from_ref(args.base_ref, args.file) if args.base_ref else version_file.read_text(encoding="utf-8")
+    )
+    next_version = bump_version(parse_version(base_text), args.part)
+    next_version_text = format_version(next_version)
+
+    if args.write:
+        current_text = version_file.read_text(encoding="utf-8")
+        version_file.write_text(replace_version(current_text, next_version), encoding="utf-8")
+
+    write_github_output(next_version_text)
+    print(next_version_text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,81 @@
+name: Auto Version Bump
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: auto-version-bump-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-version-bump:
+    name: auto-version-bump
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve bump part from PR branch
+        id: bump
+        shell: bash
+        env:
+          HEAD_BRANCH: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          case "$HEAD_BRANCH" in
+            bug/*)
+              echo "part=patch" >> "$GITHUB_OUTPUT"
+              ;;
+            feature/*)
+              echo "part=minor" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "No automatic version bump for branch: $HEAD_BRANCH"
+              ;;
+          esac
+
+      - uses: actions/checkout@v4
+        if: steps.bump.outputs.skip != 'true'
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Bump version from latest main
+        if: steps.bump.outputs.skip != 'true'
+        id: version
+        shell: bash
+        env:
+          BUMP_PART: ${{ steps.bump.outputs.part }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin "+refs/heads/main:refs/remotes/origin/main"
+          python3 .github/scripts/bump_version.py --base-ref origin/main --part "$BUMP_PART" --write
+
+      - name: Commit version bump
+        if: steps.bump.outputs.skip != 'true'
+        shell: bash
+        env:
+          HEAD_BRANCH: ${{ github.head_ref }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- pyproject.toml; then
+            echo "pyproject.toml already uses version $VERSION"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump version to $VERSION"
+          git push origin "HEAD:$HEAD_BRANCH"

--- a/.github/workflows/bump-major-version.yml
+++ b/.github/workflows/bump-major-version.yml
@@ -1,0 +1,57 @@
+name: Bump Major Version
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-major-version-pr:
+    name: create-major-version-pr
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Bump major version from latest main
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin "+refs/heads/main:refs/remotes/origin/main"
+          python3 .github/scripts/bump_version.py --base-ref origin/main --part major --write
+
+      - name: Create version bump branch
+        id: branch
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          branch="ci/bump-major-version-v${VERSION}-${RUN_ID}"
+          git switch -c "$branch"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump major version to $VERSION"
+          git push origin "$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open pull request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: bump major version to $VERSION" \
+            --body "Automated major version bump to $VERSION. Minor and patch components are reset to 0."

--- a/.github/workflows/validate-main-pr-source.yml
+++ b/.github/workflows/validate-main-pr-source.yml
@@ -75,3 +75,62 @@ jobs:
             git log --oneline --merges "${base_ref}..HEAD"
             exit 1
           fi
+
+      - name: Require expected release version bump
+        shell: bash
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+          HEAD_BRANCH: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          case "$HEAD_BRANCH" in
+            bug/*)
+              bump_part="patch"
+              ;;
+            feature/*)
+              bump_part="minor"
+              ;;
+            *)
+              echo "No release version bump required for branch: $HEAD_BRANCH"
+              exit 0
+              ;;
+          esac
+
+          base_ref="refs/remotes/origin/${BASE_BRANCH}"
+          base_version="$(
+            git show "${base_ref}:pyproject.toml" | python3 -c 'import re,sys; m=re.search(r"(?m)^version\s*=\s*\"(\d+)\.(\d+)\.(\d+)\"", sys.stdin.read()); print(".".join(m.groups()) if m else "");'
+          )"
+          head_version="$(
+            python3 -c 'import re,pathlib; m=re.search(r"(?m)^version\s*=\s*\"(\d+)\.(\d+)\.(\d+)\"", pathlib.Path("pyproject.toml").read_text(encoding="utf-8")); print(".".join(m.groups()) if m else "");'
+          )"
+
+          if [ -z "$base_version" ] || [ -z "$head_version" ]; then
+            echo "::error::Unable to parse pyproject.toml version."
+            exit 1
+          fi
+
+          expected_version="$(
+            BASE_VERSION="$base_version" BUMP_PART="$bump_part" python3 - <<'PY'
+          import os
+
+          major, minor, patch = (int(part) for part in os.environ["BASE_VERSION"].split("."))
+          part = os.environ["BUMP_PART"]
+          if part == "minor":
+              minor += 1
+              patch = 0
+          elif part == "patch":
+              patch += 1
+          else:
+              raise SystemExit(f"unsupported bump part: {part}")
+          print(f"{major}.{minor}.{patch}")
+          PY
+          )"
+
+          if [ "$head_version" != "$expected_version" ]; then
+            echo "::error::Expected pyproject.toml version $expected_version for $HEAD_BRANCH, got $head_version."
+            echo "::error::Wait for auto-version-bump.yml or re-run it after rebasing on ${BASE_BRANCH}."
+            exit 1
+          fi
+
+          echo "Version bump is valid: $base_version -> $head_version ($bump_part)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,11 @@ You are working in the `ProjectManager` repository - a Python CLI tool for multi
 4. After each module-level change (or after verifying a test suite passes), make a small commit and push it.
 5. Before each commit, run `make format` (black + isort).
 6. After each push, confirm GitHub Actions is green for the pushed commit SHA.
-7. For changes intended to ship from `main`, bump `pyproject.toml` in the same PR.
-8. After merging a stable release PR to `main`, create and push the matching `vX.Y.Z` tag from the updated `main` commit.
-9. Do not consider release work complete until the publish workflow and published artifacts are verified.
-10. Track work in the repo-root TODO note and delete completed TODO items:
+7. For `bug/*` and `feature/*` PRs targeting `main`, let `auto-version-bump.yml` update `pyproject.toml`; do not manually bump it unless the workflow cannot run.
+8. For major releases, run the `Bump Major Version` workflow; it creates a `ci/*` PR that increments major and resets minor/patch to 0.
+9. After merging a stable release PR to `main`, create and push the matching `vX.Y.Z` tag from the updated `main` commit.
+10. Do not consider release work complete until the publish workflow and published artifacts are verified.
+11. Track work in the repo-root TODO note and delete completed TODO items:
    - `./TODO.md`
 
 ## Code Organization
@@ -89,7 +90,9 @@ make check-all
 - Build metadata: `scripts/write_build_info.py` (used by `build.sh` and CI).
 - Version is in `pyproject.toml`.
 - Stable release tags must match `pyproject.toml` exactly: `pyproject.toml` version `X.Y.Z` -> tag `vX.Y.Z`.
-- Patch/bug releases increment the patch version, for example `0.1.0` -> `0.1.1`.
+- `bug/*` PRs targeting `main` automatically increment the patch version, for example `0.1.0` -> `0.1.1`.
+- `feature/*` PRs targeting `main` automatically increment the minor version and reset patch, for example `0.1.1` -> `0.2.0`.
+- Major releases are manual: run the `Bump Major Version` workflow to create a `ci/*` PR that bumps `0.2.3` -> `1.0.0`.
 
 ## CI/CD
 
@@ -98,11 +101,14 @@ GitHub Actions workflows in `.github/workflows/`:
 - `pylint.yml`: Linting
 - `publish-python.yml`: Manual PyPI release
 - `publish-release.yml`: Tag-based stable release, GitHub Release assets, PyPI publish, and Docker publish
+- `auto-version-bump.yml`: PR version bump automation for `bug/*` and `feature/*`
+- `bump-major-version.yml`: Manual major version bump PR creation
+- `validate-main-pr-source.yml`: Required main PR gate, including branch source, rebase/no-merge, and version bump validation
 
 Stable release flow:
 ```bash
 # After the release PR is merged and local main is synced:
-VERSION="$(python - <<'PY'
+VERSION="$(python3 - <<'PY'
 import tomllib
 from pathlib import Path
 print(tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]["version"])

--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,16 @@ test-cov: ## Run tests with coverage
 
 lint: ## Run linting tools
 	pylint src/ crewai_agents/
-	black --check src/ tests/ crewai_agents/
-	isort --check-only src/ tests/ crewai_agents/
+	black --check src/ tests/ crewai_agents/ .github/scripts/
+	isort --check-only src/ tests/ crewai_agents/ .github/scripts/
 	# mypy src/
 
 typecheck: ## Run mypy (ratcheted baseline)
 	python scripts/mypy_ci.py
 
 format: ## Format code
-	black src/ tests/ crewai_agents/
-	isort src/ tests/ crewai_agents/
+	black src/ tests/ crewai_agents/ .github/scripts/
+	isort src/ tests/ crewai_agents/ .github/scripts/
 
 clean: ## Clean build artifacts
 	rm -rf build/

--- a/docs/test_cases_en.md
+++ b/docs/test_cases_en.md
@@ -298,3 +298,11 @@ Notes:
 | MCP-002 | MCP | list_files excludes sensitive paths | None | 1. Call `tools/call` with `name=list_files` and `arguments={\"root\":\".\",\"max_depth\":3}`.<br>2. Inspect returned `structuredContent.files`. | Returned files exclude `.git/`, `.env`, `.agent_artifacts/`, `.cache/` by policy. | P1 | Safety |
 | MCP-003 | MCP | read_file denies `.env` | `.env` exists | 1. Call `tools/call` with `name=read_file` and `arguments={\"path\":\".env\"}`. | Returns `isError=true` and a policy error message; stdout remains JSON-only. | P1 | Negative |
 | MCP-004 | MCP | read_file redacts token-like strings by default | Create `tmp_secrets.txt` containing `ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA` | 1. Call `tools/call` with `name=read_file` and `arguments={\"path\":\"tmp_secrets.txt\"}`.<br>2. Inspect returned text. | Output contains redacted form (e.g., `ghp_***`), not the raw token string. | P2 | Safety |
+
+## 16. Release Version Automation (GitHub Actions)
+
+| Case ID | Module | Title | Preconditions | Steps | Expected Result | Priority | Type |
+|---|---|---|---|---|---|---|---|
+| REL-001 | Release/Version | `bug/*` PR auto-bumps patch version | `main` has `pyproject.toml` version `X.Y.Z`; PR targets `main` from same-repo `bug/*` branch | 1. Open or synchronize the PR.<br>2. Wait for `auto-version-bump.yml`. | Workflow commits `pyproject.toml` version `X.Y.(Z+1)` back to the PR branch; if already correct, it is a no-op. | P1 | Release |
+| REL-002 | Release/Version | `feature/*` PR auto-bumps minor version | `main` has `pyproject.toml` version `X.Y.Z`; PR targets `main` from same-repo `feature/*` branch | 1. Open or synchronize the PR.<br>2. Wait for `auto-version-bump.yml`. | Workflow commits `pyproject.toml` version `X.(Y+1).0` back to the PR branch; if already correct, it is a no-op. | P1 | Release |
+| REL-003 | Release/Version | Major bump workflow creates `ci/*` PR | `main` has `pyproject.toml` version `X.Y.Z` | 1. Run the `Bump Major Version` workflow manually.<br>2. Inspect the created PR. | Workflow creates a `ci/*` PR with `pyproject.toml` version `(X+1).0.0`; the PR can pass main source validation. | P1 | Release |

--- a/tests/whitebox/test_bump_version_script.py
+++ b/tests/whitebox/test_bump_version_script.py
@@ -1,0 +1,35 @@
+"""Tests for GitHub Actions version bump helper."""
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "bump_version.py"
+
+spec = importlib.util.spec_from_file_location("bump_version", SCRIPT_PATH)
+bump_version = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bump_version)
+
+
+def test_parse_version_reads_pyproject_version() -> None:
+    text = '[project]\nname = "demo"\nversion = "0.1.1"\n'
+
+    assert bump_version.parse_version(text) == (0, 1, 1)
+
+
+def test_bump_version_patch_increments_only_patch() -> None:
+    assert bump_version.bump_version((0, 1, 1), "patch") == (0, 1, 2)
+
+
+def test_bump_version_minor_increments_minor_and_resets_patch() -> None:
+    assert bump_version.bump_version((0, 1, 9), "minor") == (0, 2, 0)
+
+
+def test_bump_version_major_increments_major_and_resets_lower_parts() -> None:
+    assert bump_version.bump_version((0, 9, 9), "major") == (1, 0, 0)
+
+
+def test_replace_version_updates_only_project_version() -> None:
+    text = '[project]\nname = "demo"\nversion = "0.1.1"\n'
+
+    assert 'version = "0.2.0"' in bump_version.replace_version(text, (0, 2, 0))


### PR DESCRIPTION
## Summary
- add PR automation to bump patch for bug/* and minor for feature/* branches targeting main
- add manual major version workflow that opens a ci/* PR with minor/patch reset to 0
- enforce expected bug/feature version bumps in the required main PR validation check
- document release version automation in AGENTS.md and docs/test_cases_en.md

## Tests
- make format
- make lint
- pytest tests/whitebox/test_bump_version_script.py
- make test
- ruby -ryaml -e 'ARGV.each { |p| YAML.load_file(p); puts "YAML_OK #{p}" }' .github/workflows/auto-version-bump.yml .github/workflows/bump-major-version.yml .github/workflows/validate-main-pr-source.yml
- bash -n validate-version-bump.sh