### PR TITLE
ci: skip source validation for closed PR edits

### DIFF
--- a/.github/workflows/validate-main-pr-source.yml
+++ b/.github/workflows/validate-main-pr-source.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   validate-main-source-branch:
     name: validate-main-source-branch
+    if: github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
     steps:
       - name: Require same-repo feature, bug, or ci source branch


### PR DESCRIPTION
## Summary
- skip validate-main-source-branch when a closed or merged PR body/title is edited
- keep validation active for open PRs targeting main

## Tests
- make format
- ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/validate-main-pr-source.yml
- git diff --check