### PR TITLE
fix: treat requirements as release code

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -24,6 +24,7 @@ RELEASE_CODE_FILES = {
     "get_latest_release.sh",
     "install.ps1",
     "Dockerfile",
+    "requirements.txt",
 }
 
 

--- a/tests/whitebox/test_bump_version_script.py
+++ b/tests/whitebox/test_bump_version_script.py
@@ -43,6 +43,7 @@ def test_release_code_path_detection() -> None:
     assert bump_version.has_release_code_paths(["src/utils.py"])
     assert bump_version.has_release_code_paths(["scripts/write_build_info.py"])
     assert bump_version.has_release_code_paths(["build.sh"])
+    assert bump_version.has_release_code_paths(["requirements.txt"])
 
 
 def test_non_code_path_detection() -> None:


### PR DESCRIPTION
## Summary
- include requirements.txt in release-code path detection
- add a regression assertion for version bump classification

## Verification
- red: python3 -m pytest -o addopts='' tests/whitebox/test_bump_version_script.py failed before the fix on requirements.txt detection
- green: python3 -m pytest -o addopts='' tests/whitebox/test_bump_version_script.py passed after the fix
- make format
- git diff --check
