### PR TITLE
Add projman install and entrypoint validation

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,7 +14,11 @@ on:
       - 'build.sh'
       - 'setup_venv.sh'
       - 'install.sh'
+      - 'install-or-upgrade.sh'
+      - 'get_latest_release.sh'
       - 'uninstall.sh'
+      - 'README.md'
+      - 'README_EN.md'
   pull_request:
     branches: [ "main" ]
     paths:
@@ -25,7 +29,11 @@ on:
       - 'build.sh'
       - 'setup_venv.sh'
       - 'install.sh'
+      - 'install-or-upgrade.sh'
+      - 'get_latest_release.sh'
       - 'uninstall.sh'
+      - 'README.md'
+      - 'README_EN.md'
   workflow_dispatch:
 
 permissions:
@@ -54,6 +62,8 @@ jobs:
         path: |
           out/binary/projman*
           install.sh
+          install-or-upgrade.sh
+          get_latest_release.sh
           uninstall.sh
 
   install_test:
@@ -72,6 +82,9 @@ jobs:
         bash install.sh
         export PATH="$HOME/.local/bin:$PATH"
         projman --version
+        projman --help | grep -q "supported operations"
+        projman update --dry-run --user
+        bash install-or-upgrade.sh --user --dry-run
         rm "$HOME/.local/bin/projman"
 
   pytest:
@@ -89,7 +102,10 @@ jobs:
         name: build-artifacts
         path: .
     - name: Install dependencies
-      run: python -m pip install -r requirements.txt
+      run: |
+        python -m pip install -U pip
+        python -m pip install -r requirements.txt
+        python -m pip install --no-deps --no-build-isolation -e .
     - name: Run pytest
       shell: bash
       run: |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@
 ### 安装
 
 ```bash
+# 一键安装/升级（推荐）
+# 未安装 projman 时安装最新稳定版；已安装时执行 projman update 升级。
+curl -fsSL https://raw.githubusercontent.com/wangguanran/ProjectManager/main/install-or-upgrade.sh | bash -s -- --user
+
+# 已 clone 仓库时也可以直接执行
+bash install-or-upgrade.sh --user
+
 # 从 PyPI 安装（推荐）
 pip install multi-project-manager
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -12,6 +12,17 @@ ProjectManager is a project management and patch (patch/override, PO) management
 
 ## Installation
 
+### One-shot Install or Upgrade
+
+```bash
+# Installs the latest stable release when projman is missing.
+# Runs `projman update` when projman is already installed.
+curl -fsSL https://raw.githubusercontent.com/wangguanran/ProjectManager/main/install-or-upgrade.sh | bash -s -- --user
+
+# From a cloned repository:
+bash install-or-upgrade.sh --user
+```
+
 ### Python Package
 
 **From PyPI**:

--- a/install-or-upgrade.sh
+++ b/install-or-upgrade.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEFAULT_INSTALLER_URL="https://raw.githubusercontent.com/wangguanran/ProjectManager/main/get_latest_release.sh"
+
+script_dir() {
+    local source_path="${BASH_SOURCE[0]:-}"
+    if [ -n "$source_path" ] && [ -f "$source_path" ]; then
+        cd "$(dirname "$source_path")" && pwd
+        return 0
+    fi
+    return 1
+}
+
+run_installer() {
+    if [ -n "${PROJECTMANAGER_BOOTSTRAP_INSTALLER:-}" ]; then
+        exec bash "$PROJECTMANAGER_BOOTSTRAP_INSTALLER" "$@"
+    fi
+
+    local dir=""
+    if dir="$(script_dir 2>/dev/null)" && [ -f "$dir/get_latest_release.sh" ]; then
+        exec bash "$dir/get_latest_release.sh" "$@"
+    fi
+
+    local installer_url="${PROJECTMANAGER_BOOTSTRAP_INSTALLER_URL:-$DEFAULT_INSTALLER_URL}"
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "Error: curl is required to download the ProjectManager installer." >&2
+        exit 1
+    fi
+    curl -fsSL "$installer_url" | bash -s -- "$@"
+}
+
+main() {
+    if command -v projman >/dev/null 2>&1; then
+        echo "projman found: $(command -v projman)"
+        echo "Upgrading with: projman update $*"
+        exec projman update "$@"
+    fi
+
+    echo "projman not found; installing latest ProjectManager release."
+    run_installer "$@"
+}
+
+main "$@"

--- a/tests/blackbox/test_install_or_upgrade_script.py
+++ b/tests/blackbox/test_install_or_upgrade_script.py
@@ -1,0 +1,82 @@
+"""Tests for the one-shot install-or-upgrade shell script."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "install-or-upgrade.sh"
+
+
+def _write_executable(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_install_or_upgrade_installs_when_projman_missing(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    calls_file = tmp_path / "calls.txt"
+    fake_installer = tmp_path / "fake-installer.sh"
+    _write_executable(
+        fake_installer,
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'installer %s\\n' "$*" > "{calls_file}"
+""",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}/usr/bin:/bin"
+    env["PROJECTMANAGER_BOOTSTRAP_INSTALLER"] = str(fake_installer)
+
+    result = subprocess.run(
+        ["/bin/bash", str(SCRIPT), "--user", "--no-verify"],
+        cwd=str(REPO_ROOT),
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert calls_file.read_text(encoding="utf-8") == "installer --user --no-verify\n"
+
+
+def test_install_or_upgrade_updates_when_projman_exists(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    calls_file = tmp_path / "calls.txt"
+    _write_executable(
+        fake_bin / "projman",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'projman %s\\n' "$*" > "{calls_file}"
+""",
+    )
+    fake_installer = tmp_path / "fake-installer.sh"
+    _write_executable(
+        fake_installer,
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'installer %s\\n' "$*" >> "{calls_file}"
+""",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}/usr/bin:/bin"
+    env["PROJECTMANAGER_BOOTSTRAP_INSTALLER"] = str(fake_installer)
+
+    result = subprocess.run(
+        ["/bin/bash", str(SCRIPT), "--user", "--stable"],
+        cwd=str(REPO_ROOT),
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert calls_file.read_text(encoding="utf-8") == "projman update --user --stable\n"

--- a/tests/blackbox/test_projman_console_script.py
+++ b/tests/blackbox/test_projman_console_script.py
@@ -1,0 +1,75 @@
+"""Blackbox tests for the installed `projman` console script."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import toml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _projman_env() -> dict:
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    current_bin = Path(sys.executable).parent
+    env["PATH"] = f"{current_bin}{os.pathsep}{env.get('PATH', '')}"
+    return env
+
+
+def _require_projman_command(env: dict) -> str:
+    override = os.environ.get("PROJMAN_TEST_COMMAND")
+    if override:
+        return override
+
+    resolved = shutil.which("projman", path=env.get("PATH", ""))
+    assert resolved is not None, (
+        "`projman` command not found. Install the package entry point before running this test, "
+        "for example: python -m pip install -e ."
+    )
+    return resolved
+
+
+def test_installed_projman_command_runs_cli_outputs(tmp_path: Path) -> None:
+    """Install the package entry point and verify the real `projman` command."""
+
+    env = _projman_env()
+    projman = _require_projman_command(env)
+
+    help_result = subprocess.run(
+        [projman, "--help"],
+        cwd=str(tmp_path),
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert help_result.returncode == 0
+    assert "supported operations" in (help_result.stdout + help_result.stderr)
+
+    version_result = subprocess.run(
+        [projman, "--version"],
+        cwd=str(tmp_path),
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert version_result.returncode == 0
+    base_version = toml.load(str(REPO_ROOT / "pyproject.toml"))["project"]["version"]
+    assert version_result.stdout.strip().startswith(base_version)
+
+    update_result = subprocess.run(
+        [projman, "update", "--dry-run", "--user"],
+        cwd=str(tmp_path),
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert update_result.returncode == 0
+    assert "DRY-RUN: target install path:" in update_result.stdout


### PR DESCRIPTION
## Summary
- Add a one-shot install-or-upgrade shell entrypoint for projman.
- Add blackbox coverage for the installed `projman` command path.
- Extend CI install validation to exercise installed projman outputs and dry-run update.

## Tests
- make format
- make test
- make lint
- bash -n install-or-upgrade.sh get_latest_release.sh install.sh
- bash install-or-upgrade.sh --user --dry-run
