### PR TITLE
fix: treat bootstrap installer as release code

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -21,6 +21,7 @@ RELEASE_CODE_PREFIXES = (
 RELEASE_CODE_FILES = {
     "build.sh",
     "install.sh",
+    "install-or-upgrade.sh",
     "get_latest_release.sh",
     "install.ps1",
     "Dockerfile",

--- a/tests/whitebox/test_bump_version_script.py
+++ b/tests/whitebox/test_bump_version_script.py
@@ -44,6 +44,7 @@ def test_release_code_path_detection() -> None:
     assert bump_version.has_release_code_paths(["scripts/write_build_info.py"])
     assert bump_version.has_release_code_paths(["build.sh"])
     assert bump_version.has_release_code_paths(["requirements.txt"])
+    assert bump_version.has_release_code_paths(["install-or-upgrade.sh"])
 
 
 def test_non_code_path_detection() -> None:


### PR DESCRIPTION
## Summary
- classify install-or-upgrade.sh as release code for PR version bump detection
- add a regression assertion for the new bootstrap installer script

## Evidence
- PR #175 added install-or-upgrade.sh and included it in Python application workflow paths/artifacts, but .github/scripts/bump_version.py did not classify it as release code
- before the fix, the targeted regression assertion failed because has_release_code_paths(["install-or-upgrade.sh"]) returned false

## Tests
- python3 -m pytest -o addopts='' tests/whitebox/test_bump_version_script.py
- make format
- make lint
