### PR TITLE
fix: allow first top-level project creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/plugins/project_manager.py
+++ b/src/plugins/project_manager.py
@@ -65,6 +65,27 @@ def project_new(env: Dict, projects_info: Dict, project_name: str) -> bool:
                     project_info.get("board_path"),
                     project_info.get("ini_file"),
                 )
+
+        # In a freshly bootstrapped workspace, `board_new` creates only the
+        # board section. Allow that single-board state to host the first
+        # top-level project, while preserving the "unknown project" failure for
+        # workspaces that already contain real projects.
+        board_candidates = {}
+        real_projects = []
+        for existing_project, project_info in projects_info.items():
+            board_name = project_info.get("board_name")
+            if not board_name:
+                continue
+            board_candidates[board_name] = (
+                board_name,
+                project_info.get("board_path"),
+                project_info.get("ini_file"),
+            )
+            if existing_project != board_name:
+                real_projects.append(existing_project)
+        if len(board_candidates) == 1 and not real_projects:
+            return next(iter(board_candidates.values()))
+
         # No fallback strategy - if we can't determine board, return None
         return None, None, None
 

--- a/tests/blackbox/test_project_manager.py
+++ b/tests/blackbox/test_project_manager.py
@@ -82,6 +82,21 @@ def test_pm_009_project_new_append_section(workspace_a: Path) -> None:
     assert "[projA-new]" in text
 
 
+def test_pm_009_project_new_creates_first_top_level_project(empty_workspace: Path) -> None:
+    projects_dir = empty_workspace / "projects"
+    board_dir = projects_dir / "board1"
+    board_dir.mkdir(parents=True)
+    ini_path = board_dir / "board1.ini"
+    ini_path.write_text("[board1]\nPROJECT_NAME =\n", encoding="utf-8")
+
+    result = run_cli(["project_new", "myproject"], cwd=empty_workspace)
+
+    assert result.returncode == 0
+    text = ini_path.read_text(encoding="utf-8")
+    assert "[myproject]" in text
+    assert "PROJECT_NAME = myproject" in text
+
+
 def test_pm_010_project_new_unknown_board(workspace_a: Path) -> None:
     result = run_cli(["project_new", "unknownProj"], cwd=workspace_a, check=False)
     assert result.returncode != 0


### PR DESCRIPTION
## Issue
Fixes #72.

## Root cause
project_new could infer a board only from a parent project or an existing project-name prefix. After board_new creates a fresh single-board workspace, projects_info contains only the board section, so project_new myproject failed before the first top-level project could be created.

## Fix
Add a constrained single-board fallback that applies only when there is exactly one board and no existing non-board projects. Existing workspaces with real projects keep the unknown-project failure behavior.

## Verification
- make format
- ./venv/bin/python -m pytest tests/blackbox/test_project_manager.py::test_pm_009_project_new_creates_first_top_level_project tests/blackbox/test_project_manager.py::test_pm_010_project_new_unknown_board
- ./venv/bin/python -m pytest tests/blackbox/test_project_manager.py tests/whitebox/plugins/test_project_manager.py
