### PR TITLE
ci: pass repo to auto merge workflow

### DIFF
--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -33,11 +33,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.inputs.head_sha || github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          current_head="$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)"
+          current_head="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid)"
           if [ "$current_head" != "$HEAD_SHA" ]; then
             echo "PR #$PR_NUMBER head moved from $HEAD_SHA to $current_head; skipping stale auto-merge request."
             exit 0
           fi
-          gh pr merge "$PR_NUMBER" --auto --merge --delete-branch --match-head-commit "$HEAD_SHA"
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --merge --delete-branch --match-head-commit "$HEAD_SHA"

--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -47,7 +47,12 @@ def test_auto_merge_pr_workflow_enables_merge_after_required_checks() -> None:
     assert "pull-requests: write" in workflow
     assert "contents: write" in workflow
     assert "github.event.pull_request.draft == false" in workflow
-    assert 'gh pr merge "$PR_NUMBER" --auto --merge --delete-branch --match-head-commit "$HEAD_SHA"' in workflow
+    assert "REPO: ${{ github.repository }}" in workflow
+    assert 'gh pr view "$PR_NUMBER" --repo "$REPO"' in workflow
+    assert (
+        'gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --merge --delete-branch --match-head-commit "$HEAD_SHA"'
+        in workflow
+    )
 
 
 def test_required_pr_ci_workflows_run_for_all_main_pull_requests() -> None:


### PR DESCRIPTION
## Issue
Unblocks the required auto-merge status check for protected main PRs.

## Root cause
The Auto Merge PR workflow can run without a local checkout. Its gh commands relied on repository discovery from the current directory, so gh failed with 'fatal: not a git repository' before it could enable auto-merge.

## Fix
Pass the repository explicitly to both gh pr view and gh pr merge using github.repository.

## Verification
- make format
- git diff --check
- The fixed Auto Merge PR workflow was dispatched on this branch and completed successfully.
