### PR TITLE
fix: avoid log init crash in readonly cwd

### DIFF
--- a/docs/test_cases_en.md
+++ b/docs/test_cases_en.md
@@ -215,6 +215,7 @@
 | UTIL-004 | Utils | list_file_path depth & filters | Create test tree | 1. Create `tmp/a/b/file.txt`.<br>2. Run `python -c "from src.utils import list_file_path; print(list(list_file_path('tmp', max_depth=1)))"`. | Output excludes paths deeper than depth 1. | P3 | Functional |
 | LOG-001 | Logging | latest.log symlink created | Dataset A completed | 1. Run any command (e.g., `python -m src --help`).<br>2. Check `.cache/latest.log`. | Symlink exists and points to the latest log file. | P2 | Functional |
 | LOG-002 | Logging | Symlink failure does not write to stdout | Force symlink creation to fail (e.g., restricted FS) | 1. Run any command (e.g., `python -m src --help`).<br>2. If symlink creation fails, observe console output streams. | Warning is written to **stderr**; stdout stays clean. | P2 | Safety |
+| LOG-003 | Logging | Read-only cwd falls back without crashing | Current directory is not writable | 1. Run `python -m src --help` from the read-only directory.<br>2. Run `python -m src --version` from the same directory. | Both commands exit 0 without a traceback; file logging may fall back to console-only logging. | P1 | Safety |
 | PROF-001 | Profiler | ENABLE_CPROFILE toggles profiling | Use a script setting `builtins.ENABLE_CPROFILE=True` | 1. Call a function decorated with `@func_cprofile`. | cProfile stats appear in logs; process finishes normally. | P3 | Functional |
 
 ## 10. Artifact Saving Rules (src/plugins/project_builder.py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/log_manager.py
+++ b/src/log_manager.py
@@ -118,8 +118,16 @@ class LogManager:
     @staticmethod
     def _init_logger():
         """Initialize logger."""
-        # Generate log file path
-        log_file_path = get_filename("Log_", ".log", LOG_PATH)
+        log_file_path = None
+        file_logger_handlers = ["console"]
+        try:
+            # Generate log file path.
+            log_file_path = get_filename("Log_", ".log", LOG_PATH)
+            file_logger_handlers.append("file")
+        except OSError as e:
+            # Early-exit commands such as --help and --version must still work
+            # when the current directory is read-only.
+            print(f"Warning: Failed to initialize file logging: {e}", file=sys.stderr)
 
         config = {
             "version": 1.0,
@@ -163,15 +171,19 @@ class LogManager:
                     "level": "DEBUG",
                 },
                 "FileLogger": {
-                    "handlers": ["console", "file"],
+                    "handlers": file_logger_handlers,
                     "level": "DEBUG",
                 },
             },
         }
+        if log_file_path is None:
+            config["handlers"].pop("file")
+            config["handlers"].pop("file_base_time")
         logging.config.dictConfig(config)
 
         # Create symbolic link to latest log file
-        LogManager._create_latest_log_link(log_file_path)
+        if log_file_path is not None:
+            LogManager._create_latest_log_link(log_file_path)
 
         return logging.getLogger("FileLogger")
 

--- a/tests/blackbox/test_cli.py
+++ b/tests/blackbox/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
 import toml
 
 from .conftest import run_cli
@@ -41,6 +42,21 @@ def test_cli_002b_help_no_projects_dir_no_warnings(empty_workspace: Path) -> Non
     result = run_cli(["--help"], cwd=empty_workspace)
     assert "common config not found" not in result.stderr.lower()
     assert "projects directory does not exist" not in result.stderr.lower()
+
+
+@pytest.mark.parametrize("arg", ["--help", "--version"])
+def test_cli_readonly_cwd_early_exit_does_not_crash(tmp_path: Path, arg: str) -> None:
+    readonly = tmp_path / "readonly"
+    readonly.mkdir()
+    readonly.chmod(0o555)
+
+    try:
+        result = run_cli([arg], cwd=readonly, check=False)
+    finally:
+        readonly.chmod(0o755)
+
+    assert result.returncode == 0
+    assert "Traceback" not in result.stderr
 
 
 def test_cli_002c_update_dry_run_no_projects_dir_no_warnings(empty_workspace: Path) -> None:


### PR DESCRIPTION
## Issue
Fixes #73.

## Root cause
`src.log_manager` initializes a file-backed logger at import time. In a read-only current directory, creating `<cwd>/.cache/logs` raises `PermissionError` before early-exit CLI flags such as `--help` or `--version` can reach argument parsing.

## Fix
If log file path creation fails with an `OSError`, fall back to the existing console handler instead of configuring file handlers or creating `latest.log`. Normal writable workspaces still create the file logger and latest-log symlink.

## Verification
- make format
- ./venv/bin/python -m pytest tests/blackbox/test_cli.py::test_cli_readonly_cwd_early_exit_does_not_crash tests/whitebox/test_log_manager.py tests/blackbox/test_utils_log_profiler.py
- git diff --check
