### PR TITLE
TASK-78: fix template PO config name

### DIFF
--- a/docs/test_cases_en.md
+++ b/docs/test_cases_en.md
@@ -135,7 +135,7 @@
 
 | Case ID | Module | Title | Preconditions | Steps | Expected Result | Priority | Type |
 |---|---|---|---|---|---|---|---|
-| PM-001 | Board | board_new succeeds with template | `projects/template/template.ini` and `projects/template/po` exist | 1. Run `python -m src board_new boardTest`.<br>2. Check `projects/boardTest/boardTest.ini` and `projects/boardTest/po`. | Board directory created; ini uses template with first section replaced; po dir copied. | P0 | Functional |
+| PM-001 | Board | board_new succeeds with template | `projects/template/template.ini` and `projects/template/po` exist | 1. Run `python -m src board_new boardTest`.<br>2. Check `projects/boardTest/boardTest.ini` and `projects/boardTest/po`. | Board directory created; ini uses template with first section replaced; `PROJECT_PO_CONFIG` matches copied `po/po_template`; po dir copied. | P0 | Functional |
 | PM-002 | Board | board_new succeeds without template | Temporarily rename `projects/template` | 1. Run `python -m src board_new boardNoTpl`.<br>2. Check ini and po structure.<br>3. Restore template dir. | Default ini content used; po dir contains `po_template/patches` and `overrides`. | P1 | Compatibility |
 | PM-003 | Board | board_new rejects empty/./.. | None | 1. Run `python -m src board_new ""` and `python -m src board_new .` and `python -m src board_new ..`. | Error for each; no directories created. | P1 | Negative |
 | PM-004 | Board | board_new rejects separators/absolute path | None | 1. Run `python -m src board_new a/b`.<br>2. Run `python -m src board_new /abs/path`. | Errors; no directories created. | P1 | Negative |

--- a/projects/template/template.ini
+++ b/projects/template/template.ini
@@ -1,4 +1,4 @@
 [template]
 PROJECT_NAME=
 PROJECT_VERSION=
-PROJECT_PO_CONFIG=po_template01
+PROJECT_PO_CONFIG=po_template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/plugins/project_manager.py
+++ b/src/plugins/project_manager.py
@@ -203,6 +203,12 @@ def project_new(env: Dict, projects_info: Dict, project_name: str) -> bool:
     # Append the new project section
     new_lines.append(f"[{project_name}]\n")
     new_lines.append(f"PROJECT_NAME = {project_name_value}\n")
+    if not parent_config:
+        board_project_info = projects_info.get(board_name, {})
+        board_config = board_project_info.get("config", {})
+        board_po_config = str(board_config.get("PROJECT_PO_CONFIG", "") or "").strip()
+        if board_po_config:
+            new_lines.append(f"PROJECT_PO_CONFIG = {board_po_config}\n")
 
     # Write back preserving all original comments and formatting elsewhere
     try:

--- a/tests/blackbox/test_project_manager.py
+++ b/tests/blackbox/test_project_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shutil
+from configparser import ConfigParser
 from pathlib import Path
 
 from .conftest import REPO_ROOT, run_cli
@@ -15,12 +16,33 @@ def _copy_template(target: Path) -> None:
         shutil.copytree(src, target / "projects" / "template")
 
 
-def test_pm_001_board_new_with_template(workspace_a: Path) -> None:
-    _copy_template(workspace_a)
-    result = run_cli(["board_new", "boardTest"], cwd=workspace_a)
+def test_pm_001_board_new_with_template(empty_workspace: Path) -> None:
+    _copy_template(empty_workspace)
+    result = run_cli(["board_new", "boardTest"], cwd=empty_workspace)
     assert result.returncode == 0
-    assert (workspace_a / "projects" / "boardTest" / "boardTest.ini").exists()
-    assert (workspace_a / "projects" / "boardTest" / "po").exists()
+    board_dir = empty_workspace / "projects" / "boardTest"
+    ini_path = board_dir / "boardTest.ini"
+    po_dir = board_dir / "po"
+    assert ini_path.exists()
+    assert po_dir.exists()
+
+    run_cli(["project_new", "app1"], cwd=empty_workspace)
+    po_list_result = run_cli(["po_list", "app1", "--short"], cwd=empty_workspace)
+
+    config = ConfigParser()
+    config.optionxform = str
+    config.read(ini_path, encoding="utf-8")
+    po_config = config["boardTest"].get("PROJECT_PO_CONFIG", "").strip()
+    copied_po_names = sorted(path.name for path in po_dir.iterdir() if path.is_dir())
+
+    errors = []
+    if po_config != "po_template":
+        errors.append(f"PROJECT_PO_CONFIG should be po_template, got {po_config!r}")
+    if copied_po_names != ["po_template"]:
+        errors.append(f"copied PO dirs should be ['po_template'], got {copied_po_names!r}")
+    if "po_template" not in po_list_result.stdout:
+        errors.append(f"po_list app1 --short should show po_template, got: {po_list_result.stdout!r}")
+    assert not errors, "\n".join(errors)
 
 
 def test_pm_002_board_new_without_template(workspace_a: Path) -> None:


### PR DESCRIPTION
## Summary
- align the template board default PO config with the copied po_template directory
- persist the board PO config when creating the first top-level project from a template board
- update PM-001 blackbox coverage and test-case source of truth

## Verification
- make format
- pytest tests/blackbox/test_project_manager.py::test_pm_001_board_new_with_template
- pytest tests/blackbox/test_project_manager.py tests/blackbox/test_config.py
- pytest tests/whitebox/test_main.py

Closes #78