### PR TITLE
TASK-80: deep merge inherited project config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.4"
+version = "0.2.5"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/plugins/project_manager.py
+++ b/src/plugins/project_manager.py
@@ -35,7 +35,11 @@ def project_new(env: Dict, projects_info: Dict, project_name: str) -> bool:
         if parent and parent in projects_info:
             config.update(get_inherited_config(projects_info, parent))
         if name in projects_info:
-            config.update(projects_info[name])
+            for key, value in projects_info[name].items():
+                if isinstance(config.get(key), dict) and isinstance(value, dict):
+                    config[key] = {**config[key], **value}
+                else:
+                    config[key] = value
         return config
 
     def find_board_for_project(project_name, projects_info):

--- a/tests/whitebox/plugins/test_project_manager.py
+++ b/tests/whitebox/plugins/test_project_manager.py
@@ -324,9 +324,7 @@ class TestProjectNew:
         # Verify the actual INI file content to ensure multi-level inheritance worked
         content = ini_file.read_text()
         assert "[grandparent-parent-child]" in content
-        # Check that the project name includes inherited customer name (from direct parent)
-        # Note: platform from grandparent is not inherited in current implementation
-        assert "PROJECT_NAME = grandparent-parent-child_customer456" in content
+        assert "PROJECT_NAME = platform_grandparent-parent-child_customer456" in content
 
     def test_project_new_config_merge(self, tmp_path):
         """Test project_new with config merging."""
@@ -1306,9 +1304,7 @@ PROJECT_PLATFORM=platform
         # Verify project section was added
         assert "[base-feature-child]" in content
 
-        # Verify inherited project name includes customer (from direct parent)
-        # Note: platform from grandparent is not inherited in current implementation
-        assert "PROJECT_NAME = base-feature-child_customer456" in content
+        assert "PROJECT_NAME = platform_base-feature-child_customer456" in content
 
         # Verify the inheritance chain worked correctly
         # The project should inherit from base-feature, which inherits from base


### PR DESCRIPTION
## Summary
- deep-merge inherited project config dictionaries during project_new recursion
- preserve ancestor PROJECT_PLATFORM when the direct parent supplies PROJECT_CUSTOMER
- update existing multi-level inheritance whitebox expectations

## Verification
- make format
- pytest tests/whitebox/plugins/test_project_manager.py::TestProjectNew::test_project_new_multi_level_inheritance tests/whitebox/plugins/test_project_manager.py::TestProjectNew::test_project_new_verify_inheritance_in_ini
- pytest tests/whitebox/plugins/test_project_manager.py
- pytest tests/blackbox/test_project_manager.py

Closes #80