### PR TITLE
TASK-84: include root actions in emit plans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.5"
+version = "0.2.6"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/plugins/patch_override.py
+++ b/src/plugins/patch_override.py
@@ -150,6 +150,18 @@ def _split_override_repo_prefix(rel_path: str, repo_names: List[str]) -> Tuple[s
     return "root", rel_path
 
 
+def _per_repo_plan_actions(
+    repo_entries: List[Tuple[str, str]],
+    actions_by_repo: Dict[str, List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    per_repo_actions = [
+        {"repo": repo_name, "actions": actions_by_repo.get(repo_name, [])} for _repo_path, repo_name in repo_entries
+    ]
+    if not any(repo_name == "root" for _repo_path, repo_name in repo_entries) and actions_by_repo.get("root"):
+        per_repo_actions.append({"repo": "root", "actions": actions_by_repo["root"]})
+    return per_repo_actions
+
+
 def build_po_apply_plan(
     env: Dict[str, Any],
     projects_info: Dict[str, Any],
@@ -290,10 +302,7 @@ def build_po_apply_plan(
             for repo_path, repo_name in repo_entries
         ],
         "pos": po_items,
-        "per_repo_actions": [
-            {"repo": repo_name, "actions": actions_by_repo.get(repo_name, [])} for _repo_path, repo_name in repo_entries
-        ]
-        + ([{"repo": "root", "actions": actions_by_repo.get("root", [])}] if not repo_entries else []),
+        "per_repo_actions": _per_repo_plan_actions(repo_entries, actions_by_repo),
     }
 
 
@@ -450,10 +459,7 @@ def build_po_revert_plan(
             for repo_path, repo_name in repo_entries
         ],
         "pos": po_items,
-        "per_repo_actions": [
-            {"repo": repo_name, "actions": actions_by_repo.get(repo_name, [])} for _repo_path, repo_name in repo_entries
-        ]
-        + ([{"repo": "root", "actions": actions_by_repo.get("root", [])}] if not repo_entries else []),
+        "per_repo_actions": _per_repo_plan_actions(repo_entries, actions_by_repo),
     }
 
 

--- a/tests/whitebox/plugins/test_patch_override_emit_plan_root.py
+++ b/tests/whitebox/plugins/test_patch_override_emit_plan_root.py
@@ -1,0 +1,98 @@
+from src.plugins.patch_override import build_po_apply_plan, build_po_revert_plan
+
+
+def _project_info(project_name: str, board_name: str, po_name: str) -> dict:
+    return {project_name: {"board_name": board_name, "config": {"PROJECT_PO_CONFIG": po_name}}}
+
+
+def _write_override(projects_path, board_name: str, po_name: str, rel_path: str) -> None:
+    target = projects_path / board_name / "po" / po_name / "overrides" / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("override\n", encoding="utf-8")
+
+
+def _actions_by_repo(plan: dict) -> dict:
+    return {entry["repo"]: entry["actions"] for entry in plan["per_repo_actions"]}
+
+
+def test_po_apply_emit_plan_keeps_root_actions_with_child_repositories(tmp_path, monkeypatch):
+    workspace = tmp_path
+    projects_path = workspace / "projects"
+    repo1 = workspace / "repo1"
+    repo1.mkdir()
+
+    board_name = "board"
+    po_name = "po1"
+    project_name = "proj"
+    _write_override(projects_path, board_name, po_name, "root.txt")
+    _write_override(projects_path, board_name, po_name, "repo1/child.txt")
+
+    monkeypatch.chdir(workspace)
+    plan = build_po_apply_plan(
+        {
+            "projects_path": str(projects_path),
+            "repositories": [(str(repo1), "repo1")],
+            "po_configs": {},
+        },
+        _project_info(project_name, board_name, po_name),
+        project_name,
+    )
+
+    actions = _actions_by_repo(plan)
+    assert list(actions) == ["repo1", "root"]
+    assert actions["repo1"][0]["path_in_repo"] == "child.txt"
+    assert actions["root"][0]["path_in_repo"] == "root.txt"
+
+
+def test_po_revert_emit_plan_keeps_root_actions_with_child_repositories(tmp_path, monkeypatch):
+    workspace = tmp_path
+    projects_path = workspace / "projects"
+    repo1 = workspace / "repo1"
+    repo1.mkdir()
+
+    board_name = "board"
+    po_name = "po1"
+    project_name = "proj"
+    _write_override(projects_path, board_name, po_name, "root.txt")
+    _write_override(projects_path, board_name, po_name, "repo1/child.txt")
+
+    monkeypatch.chdir(workspace)
+    plan = build_po_revert_plan(
+        {
+            "projects_path": str(projects_path),
+            "repositories": [(str(repo1), "repo1")],
+            "po_configs": {},
+        },
+        _project_info(project_name, board_name, po_name),
+        project_name,
+    )
+
+    actions = _actions_by_repo(plan)
+    assert list(actions) == ["repo1", "root"]
+    assert actions["repo1"][0]["path_in_repo"] == "child.txt"
+    assert actions["root"][0]["path_in_repo"] == "root.txt"
+
+
+def test_emit_plan_omits_empty_root_entry_with_child_repositories(tmp_path, monkeypatch):
+    workspace = tmp_path
+    projects_path = workspace / "projects"
+    repo1 = workspace / "repo1"
+    repo1.mkdir()
+
+    board_name = "board"
+    po_name = "po1"
+    project_name = "proj"
+    _write_override(projects_path, board_name, po_name, "repo1/child.txt")
+
+    monkeypatch.chdir(workspace)
+    plan = build_po_apply_plan(
+        {
+            "projects_path": str(projects_path),
+            "repositories": [(str(repo1), "repo1")],
+            "po_configs": {},
+        },
+        _project_info(project_name, board_name, po_name),
+        project_name,
+    )
+
+    assert [entry["repo"] for entry in plan["per_repo_actions"]] == ["repo1"]


### PR DESCRIPTION
## Summary

Fixes #84.

- Adds regression coverage for multi-repository emit plans where child-repo actions and root actions coexist.
- Reuses one helper for `po_apply` and `po_revert` `per_repo_actions` generation.
- Includes `repo: root` only when root has planned actions and is not already listed by configured repositories.

## Validation

- `make format`
- `python -m pytest tests/whitebox/plugins/test_patch_override_emit_plan_root.py -q`
- `python -m pytest tests/whitebox/plugins/test_patch_override_emit_plan_root.py tests/whitebox/plugins/test_patch_override.py tests/blackbox/test_patch_override.py -q`