### PR TITLE
TASK-93: sanitize sample project metadata paths

### DIFF
--- a/projects/board01/projects.json
+++ b/projects/board01/projects.json
@@ -1,6 +1,6 @@
 {
   "board_name": "board01",
-  "board_path": "/home/wangguanran/ProjectManager/projects/board01",
+  "board_path": "projects/board01",
   "last_updated": "2026-02-03T00:21:52.458744",
   "projects": [
     {
@@ -16,7 +16,7 @@
         "board01-project02",
         "board01-error"
       ],
-      "ini_file": "/home/wangguanran/ProjectManager/projects/board01/board01.ini"
+      "ini_file": "projects/board01/board01.ini"
     },
     {
       "project_name": "board01-project01",
@@ -32,7 +32,7 @@
         "board01-project01-test",
         "board01-project01-test01"
       ],
-      "ini_file": "/home/wangguanran/ProjectManager/projects/board01/board01.ini"
+      "ini_file": "projects/board01/board01.ini"
     },
     {
       "project_name": "board01-project02",
@@ -44,7 +44,7 @@
       },
       "parent": "board01",
       "children": [],
-      "ini_file": "/home/wangguanran/ProjectManager/projects/board01/board01.ini"
+      "ini_file": "projects/board01/board01.ini"
     },
     {
       "project_name": "board01-project01-test",
@@ -57,7 +57,7 @@
       },
       "parent": "board01-project01",
       "children": [],
-      "ini_file": "/home/wangguanran/ProjectManager/projects/board01/board01.ini"
+      "ini_file": "projects/board01/board01.ini"
     },
     {
       "project_name": "board01-error",
@@ -69,7 +69,7 @@
       },
       "parent": "board01",
       "children": [],
-      "ini_file": "/home/wangguanran/ProjectManager/projects/board01/board01.ini"
+      "ini_file": "projects/board01/board01.ini"
     },
     {
       "project_name": "board01-project01-test01",
@@ -82,7 +82,7 @@
       },
       "parent": "board01-project01",
       "children": [],
-      "ini_file": "/home/wangguanran/ProjectManager/projects/board01/board01.ini"
+      "ini_file": "projects/board01/board01.ini"
     }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.6"
+version = "0.2.7"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/tests/blackbox/test_sample_projects_metadata.py
+++ b/tests/blackbox/test_sample_projects_metadata.py
@@ -1,0 +1,33 @@
+"""Regression tests for committed sample project metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+SENSITIVE_PATH_PATTERNS = [
+    re.compile(r"/Users/[^/\s\"]+"),
+    re.compile(r"/home/[^/\s\"]+"),
+    re.compile(r"\.codex"),
+]
+
+
+def test_sample_projects_metadata_uses_portable_relative_paths() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    sample_files = sorted((repo_root / "projects").glob("*/projects.json"))
+
+    assert sample_files
+    for sample_file in sample_files:
+        text = sample_file.read_text(encoding="utf-8")
+        for pattern in SENSITIVE_PATH_PATTERNS:
+            assert pattern.search(text) is None
+
+        data = json.loads(text)
+        board_path = data.get("board_path", "")
+        assert Path(board_path).is_absolute() is False
+
+        for project in data.get("projects", []):
+            ini_file = project.get("ini_file")
+            if ini_file:
+                assert Path(ini_file).is_absolute() is False

--- a/tests/blackbox/test_sample_projects_metadata.py
+++ b/tests/blackbox/test_sample_projects_metadata.py
@@ -8,9 +8,18 @@ from pathlib import Path
 
 SENSITIVE_PATH_PATTERNS = [
     re.compile(r"/Users/[^/\s\"]+"),
-    re.compile(r"/home/[^/\s\"]+"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
     re.compile(r"\.codex"),
 ]
+
+
+def test_sensitive_path_patterns_ignore_documented_home_placeholders() -> None:
+    placeholder_path = "/home/<user>/ProjectManager"
+    real_user_path = "/home/alice/ProjectManager"
+    linux_home_pattern = SENSITIVE_PATH_PATTERNS[1]
+
+    assert linux_home_pattern.search(placeholder_path) is None
+    assert linux_home_pattern.search(real_user_path) is not None
 
 
 def test_sample_projects_metadata_uses_portable_relative_paths() -> None:


### PR DESCRIPTION
## Summary
- Sanitizes committed sample project metadata to use repository-relative paths.
- Adds a regression test that scans committed sample projects metadata for host-specific absolute path patterns.

## Verification
- make format
- pytest tests/blackbox/test_sample_projects_metadata.py tests/blackbox/test_config.py tests/whitebox/test_main.py

Closes #93