### PR TITLE
TASK-102: keep operation registry syntax python39 compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/operations/registry.py
+++ b/src/operations/registry.py
@@ -4,17 +4,17 @@ Simple registry for function-based operations.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 REGISTRY: Dict[str, Callable[..., Any]] = {}
 
 
 def register(
-    name: str | None = None,
+    name: Optional[str] = None,
     *,
     needs_repositories: bool = False,
     needs_projects: bool = True,
-    desc: str | None = None,
+    desc: Optional[str] = None,
 ):
     """
     Decorator to register a function as a CLI operation.

--- a/src/plugins/po_plugins/registry.py
+++ b/src/plugins/po_plugins/registry.py
@@ -7,7 +7,7 @@ Plugins are registered by importing modules under `src/plugins/po_plugins/`.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from .runtime import PoPluginContext, PoPluginRuntime
 
@@ -57,8 +57,8 @@ def register_simple_plugin(
     revert_order: int,
     apply: Callable[[PoPluginContext, PoPluginRuntime], bool],
     revert: Callable[[PoPluginContext, PoPluginRuntime], bool],
-    list_files: Callable[[str, PoPluginRuntime], Dict[str, Any]] | None = None,
-    ensure_structure: Callable[[str, bool], None] | None = None,
+    list_files: Optional[Callable[[str, PoPluginRuntime], Dict[str, Any]]] = None,
+    ensure_structure: Optional[Callable[[str, bool], None]] = None,
 ) -> None:
     register_plugin(
         PoPlugin(

--- a/src/plugins/po_plugins/runtime.py
+++ b/src/plugins/po_plugins/runtime.py
@@ -47,7 +47,7 @@ class PoPluginRuntime:
         project_name: str,
         repositories: List[Tuple[str, str]],
         workspace_root: str,
-        po_configs: Dict[str, Dict[str, Any]] | None = None,
+        po_configs: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> None:
         self.board_name = board_name
         self.project_name = project_name
@@ -78,7 +78,12 @@ class PoPluginRuntime:
             return None
 
     @staticmethod
-    def _format_command(command, cwd: str | None = None, description: str = "", shell: bool = False) -> Dict[str, Any]:
+    def _format_command(
+        command,
+        cwd: Optional[str] = None,
+        description: str = "",
+        shell: bool = False,
+    ) -> Dict[str, Any]:
         if isinstance(command, list):
             cmd_str = " ".join(f'"{arg}"' if " " in arg else arg for arg in command)
         else:
@@ -119,7 +124,7 @@ class PoPluginRuntime:
         repo_name: str,
         command,
         *,
-        cwd: str | None = None,
+        cwd: Optional[str] = None,
         description: str = "",
         shell: bool = False,
     ) -> subprocess.CompletedProcess:
@@ -161,7 +166,7 @@ class PoPluginRuntime:
         repo_name: str,
         command,
         *,
-        cwd: str | None = None,
+        cwd: Optional[str] = None,
         description: str = "",
         shell: bool = False,
         returncode: int = 0,

--- a/tests/whitebox/test_python_compat.py
+++ b/tests/whitebox/test_python_compat.py
@@ -7,22 +7,42 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
+STARTUP_IMPORT_PATHS = [
+    REPO_ROOT / "src" / "__main__.py",
+    REPO_ROOT / "src" / "operations" / "registry.py",
+    REPO_ROOT / "src" / "plugins" / "po_plugins" / "runtime.py",
+    REPO_ROOT / "src" / "plugins" / "po_plugins" / "registry.py",
+]
 
-def test_operation_registry_source_parses_as_python39() -> None:
-    source_path = REPO_ROOT / "src" / "operations" / "registry.py"
-    source = source_path.read_text(encoding="utf-8")
 
-    ast.parse(source, filename=str(source_path), feature_version=(3, 9))
+def _relative_path(source_path: Path) -> str:
+    return str(source_path.relative_to(REPO_ROOT))
 
 
-def test_operation_registry_avoids_python310_union_type_syntax() -> None:
-    source_path = REPO_ROOT / "src" / "operations" / "registry.py"
-    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+def _has_bit_or_union(annotation: ast.AST) -> bool:
+    return any(isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr) for node in ast.walk(annotation))
 
+
+def test_startup_import_sources_parse_as_python38() -> None:
+    for source_path in STARTUP_IMPORT_PATHS:
+        source = source_path.read_text(encoding="utf-8")
+
+        ast.parse(source, filename=str(source_path), feature_version=(3, 8))
+
+
+def test_startup_import_sources_avoid_python310_union_type_syntax() -> None:
     union_type_annotations = []
-    for node in ast.walk(tree):
-        annotation = getattr(node, "annotation", None)
-        if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
-            union_type_annotations.append((annotation.lineno, annotation.col_offset))
+    for source_path in STARTUP_IMPORT_PATHS:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+
+        for node in ast.walk(tree):
+            annotation = getattr(node, "annotation", None)
+            if isinstance(annotation, ast.AST) and _has_bit_or_union(annotation):
+                union_type_annotations.append((_relative_path(source_path), annotation.lineno, annotation.col_offset))
+
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                returns = node.returns
+                if returns is not None and _has_bit_or_union(returns):
+                    union_type_annotations.append((_relative_path(source_path), returns.lineno, returns.col_offset))
 
     assert union_type_annotations == []

--- a/tests/whitebox/test_python_compat.py
+++ b/tests/whitebox/test_python_compat.py
@@ -1,0 +1,28 @@
+"""Python version compatibility checks for declared support versions."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_operation_registry_source_parses_as_python39() -> None:
+    source_path = REPO_ROOT / "src" / "operations" / "registry.py"
+    source = source_path.read_text(encoding="utf-8")
+
+    ast.parse(source, filename=str(source_path), feature_version=(3, 9))
+
+
+def test_operation_registry_avoids_python310_union_type_syntax() -> None:
+    source_path = REPO_ROOT / "src" / "operations" / "registry.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+
+    union_type_annotations = []
+    for node in ast.walk(tree):
+        annotation = getattr(node, "annotation", None)
+        if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
+            union_type_annotations.append((annotation.lineno, annotation.col_offset))
+
+    assert union_type_annotations == []


### PR DESCRIPTION
## Summary
- Add a regression test that keeps the CLI operation registry source free of Python 3.10-only union type syntax.
- Replace registry optional string annotations with Python 3.8/3.9-compatible typing.Optional without changing runtime behavior.

## Verification
- make format
- pytest tests/whitebox/test_python_compat.py -q
- pytest tests/blackbox/test_cli.py -q
- python -m src --version