### PR TITLE
TASK-106: skip reverting preexisting patches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.8"
+version = "0.2.9"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/plugins/patch_override.py
+++ b/src/plugins/patch_override.py
@@ -370,6 +370,19 @@ def build_po_revert_plan(
         # patches revert
         for rel_path in plugin_files.get("patches", {}).get("patch_files", []) or []:
             repo_name = _repo_name_from_po_relpath(rel_path)
+            repo_root = runtime.repo_map.get(repo_name)
+            record = runtime.load_applied_record(repo_root, po_name) if repo_root else None
+            patch_records = (record or {}).get("patches") or []
+            patch_record = next(
+                (
+                    item
+                    for item in patch_records
+                    if item.get("patch_file") == os.path.join("patches", rel_path) or item.get("patch_file") == rel_path
+                ),
+                None,
+            )
+            if patch_record and patch_record.get("status") == "already_applied":
+                continue
             actions_by_repo.setdefault(repo_name, []).append(
                 {
                     "type": "patch_reverse",

--- a/src/plugins/po_plugins/patches.py
+++ b/src/plugins/po_plugins/patches.py
@@ -14,6 +14,8 @@ from .registry import APPLY_PHASE_PER_PO, REVERT_PHASE_PER_PO, register_simple_p
 from .runtime import PoPluginContext, PoPluginRuntime
 from .utils import extract_patch_targets
 
+SKIPPED_PATCH_STATUSES = {"already_applied"}
+
 
 def _apply_patches(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
     log.debug("po_name: '%s', po_patch_dir: '%s'", ctx.po_name, ctx.po_patch_dir)
@@ -68,12 +70,12 @@ def _apply_patches(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                 return False
 
             record = runtime.get_repo_record(ctx, patch_target, repo_name)
-            record["patches"].append(
-                {
-                    "patch_file": os.path.relpath(patch_file, start=ctx.po_path),
-                    "targets": patch_targets,
-                }
-            )
+            patch_entry = {
+                "patch_file": os.path.relpath(patch_file, start=ctx.po_path),
+                "targets": patch_targets,
+                "status": "applied",
+            }
+            record["patches"].append(patch_entry)
 
             result = runtime.execute_command(
                 ctx,
@@ -105,6 +107,7 @@ def _apply_patches(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                         rel_path,
                         repo_name,
                     )
+                    patch_entry["status"] = "already_applied"
                     continue
 
                 log.error("Failed to apply patch '%s': %s", patch_file, summarize_output(result.stderr))
@@ -151,6 +154,23 @@ def _revert_patches(ctx: PoPluginContext, runtime: PoPluginRuntime) -> bool:
                 log.error("Cannot find repo path for '%s'", repo_name)
                 return False
             patch_file = os.path.join(current_dir, fname)
+            record = runtime.load_applied_record(patch_target, ctx.po_name)
+            patches = (record or {}).get("patches") or []
+            patch_record = next(
+                (
+                    item
+                    for item in patches
+                    if item.get("patch_file") == os.path.join("patches", rel_path) or item.get("patch_file") == rel_path
+                ),
+                None,
+            )
+            if patch_record and patch_record.get("status") in SKIPPED_PATCH_STATUSES:
+                log.info(
+                    "patch '%s' was already applied before po_apply for repo '%s'; skipping revert.",
+                    rel_path,
+                    repo_name,
+                )
+                continue
             log.info("reverting patch: '%s' from dir: '%s'", patch_file, patch_target)
             try:
                 if ctx.dry_run:

--- a/tests/blackbox/test_patch_override.py
+++ b/tests/blackbox/test_patch_override.py
@@ -139,6 +139,14 @@ def test_po_005d_preexisting_patch_is_not_reverted(workspace_a: Path) -> None:
     record = json.loads(record_path.read_text(encoding="utf-8"))
     assert any(item.get("status") == "already_applied" for item in record.get("patches", []))
 
+    plan = run_cli(["po_revert", "projA", "--emit-plan"], cwd=workspace_a)
+    assert plan.returncode == 0
+    payload = json.loads(plan.stdout)
+    actions = [action for repo in payload["per_repo_actions"] for action in repo["actions"]]
+    assert not any(
+        action.get("type") == "patch_reverse" and action.get("source") == "patches/tmp_file.patch" for action in actions
+    )
+
     revert = run_cli(["po_revert", "projA"], cwd=workspace_a)
     assert revert.returncode == 0
     assert target.read_text(encoding="utf-8") == "line1\nline2"

--- a/tests/blackbox/test_patch_override.py
+++ b/tests/blackbox/test_patch_override.py
@@ -129,6 +129,21 @@ def test_po_005_patch_apply_success(workspace_a: Path) -> None:
     assert "line2" in target.read_text(encoding="utf-8")
 
 
+def test_po_005d_preexisting_patch_is_not_reverted(workspace_a: Path) -> None:
+    target = workspace_a / "src" / "tmp_file.txt"
+    assert target.read_text(encoding="utf-8") == "line1\nline2"
+
+    result = run_cli(["po_apply", "projA"], cwd=workspace_a)
+    assert result.returncode == 0
+    record_path = workspace_a / ".cache" / "po_applied" / "boardA" / "projA" / "po_base.json"
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert any(item.get("status") == "already_applied" for item in record.get("patches", []))
+
+    revert = run_cli(["po_revert", "projA"], cwd=workspace_a)
+    assert revert.returncode == 0
+    assert target.read_text(encoding="utf-8") == "line1\nline2"
+
+
 def test_po_005b_commit_apply_success(workspace_a: Path) -> None:
     commits_dir = workspace_a / "projects" / "boardA" / "po" / "po_base" / "commits"
     commits_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Record patch entries as applied or already_applied during po_apply.
- Skip po_revert for patch entries that were already present before po_apply.
- Add a blackbox regression for preexisting patch content.

Fixes #106

## Verification
- make format
- python -m pytest tests/blackbox/test_patch_override.py tests/whitebox/plugins/test_patch_override.py -q