### PR TITLE
TASK-117: reject duplicate projects across boards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.9"
+version = "0.2.10"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -117,7 +117,7 @@ def _load_all_projects(projects_path, common_configs):
 
     # Use the passed common_configs parameter
 
-    for item in os.listdir(projects_path):
+    for item in sorted(os.listdir(projects_path)):
         board_name = item
         board_path = os.path.join(projects_path, board_name)
         if not os.path.isdir(board_path) or board_name in exclude_dirs:
@@ -161,6 +161,13 @@ def _load_all_projects(projects_path, common_configs):
         config = configupdater.ConfigUpdater()
         config.read(ini_file, encoding="utf-8")
         for project_name in config.sections():
+            if project_name in projects_info:
+                previous = projects_info[project_name]
+                msg = (
+                    f"Duplicate project '{project_name}' found across boards: " f"{previous['ini_file']} and {ini_file}"
+                )
+                log.error(msg)
+                raise ValueError(msg)
             config_dict = {k.upper(): _strip_comment(v.value) for k, v in config[project_name].items()}
             raw_configs[project_name] = config_dict
             projects_info[project_name] = {

--- a/tests/whitebox/test_main.py
+++ b/tests/whitebox/test_main.py
@@ -430,6 +430,24 @@ PROJECT_NAME=project2
         assert result["project1"]["board_name"] == "board01"
         assert result["project2"]["board_name"] == "board02"
 
+    def test_load_all_projects_duplicate_project_across_boards_errors(self):
+        """Duplicate project sections across boards fail deterministically."""
+        projects_path = self._create_temp_projects_structure()
+
+        self._create_board_structure(projects_path, "board01", "[shared]\nPROJECT_NAME=board01_shared\n")
+        self._create_board_structure(projects_path, "board02", "[shared]\nPROJECT_NAME=board02_shared\n")
+
+        try:
+            self._load_projects_with_config(projects_path)
+        except ValueError as exc:
+            message = str(exc)
+        else:
+            raise AssertionError("Expected duplicate project definitions to raise ValueError")
+
+        assert "Duplicate project 'shared'" in message
+        assert os.path.join("board01", "board01.ini") in message
+        assert os.path.join("board02", "board02.ini") in message
+
     def test_load_all_projects_invalid_projects_handling(self):
         """Test handling of invalid projects."""
         projects_path = self._create_temp_projects_structure()


### PR DESCRIPTION
## Summary
- reject duplicate project section names across different boards during project loading
- make board traversal deterministic before duplicate detection
- add a whitebox regression test for duplicate cross-board project names

## Verification
- make format
- python -m pytest tests/whitebox/test_main.py::TestLoadAllProjects::test_load_all_projects_duplicate_project_across_boards_errors
- python -m pytest tests/whitebox/test_main.py
- python -m pytest tests/blackbox/test_config.py tests/blackbox/test_cli.py
- python -m pytest tests/blackbox/test_project_manager.py
- python -m pytest tests/blackbox/test_patch_override.py