### PR TITLE
TASK-128: validate hook callable signatures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.12"
+version = "0.2.13"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/hooks/executor.py
+++ b/src/hooks/executor.py
@@ -128,18 +128,19 @@ def validate_hooks(hook_type: Union[str, "HookType"], platform: Optional[str] = 
 
             sig = inspect.signature(hook_func)
 
-            # Check if function accepts context parameter
-            if "context" in sig.parameters or len(sig.parameters) > 0:
-                validation_results["valid_hooks"].append(
-                    {"name": hook_name, "description": hook_info.get("description", "")}
-                )
-            else:
-                validation_results["invalid_hooks"].append(
-                    {"name": hook_name, "error": "Function must accept at least one parameter"}
-                )
-                validation_results["valid"] = False
+            # execute_hooks calls hook_func(context), so validate the same call shape.
+            sig.bind(object())
+            validation_results["valid_hooks"].append(
+                {"name": hook_name, "description": hook_info.get("description", "")}
+            )
 
-        except (RuntimeError, ValueError, TypeError, OSError) as e:
+        except TypeError as e:
+            validation_results["invalid_hooks"].append(
+                {"name": hook_name, "error": f"Function must be callable with one context argument: {str(e)}"}
+            )
+            validation_results["valid"] = False
+
+        except (RuntimeError, ValueError, OSError) as e:
             validation_results["invalid_hooks"].append({"name": hook_name, "error": f"Validation error: {str(e)}"})
             validation_results["valid"] = False
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -187,6 +187,39 @@ def test_validate_hooks_no_arg_invalid() -> None:
     assert any(item["name"] == "noargs" for item in res["invalid_hooks"])
 
 
+def test_validate_hooks_rejects_signatures_that_cannot_accept_context() -> None:
+    """HOOK-007: validate_hooks matches the execute_hooks one-context call."""
+
+    def single_context(ctx: Dict[str, Any]) -> bool:
+        _ = ctx
+        return True
+
+    def context_with_default(ctx: Dict[str, Any], optional: bool = True) -> bool:
+        _ = ctx, optional
+        return True
+
+    def context_with_varargs(ctx: Dict[str, Any], *extra: Any) -> bool:
+        _ = ctx, extra
+        return True
+
+    def two_required_args(first: Dict[str, Any], second: Dict[str, Any]) -> bool:
+        _ = first, second
+        return True
+
+    register_hook(HookType.CUSTOM, "single_context", single_context)
+    register_hook(HookType.CUSTOM, "context_with_default", context_with_default)
+    register_hook(HookType.CUSTOM, "context_with_varargs", context_with_varargs)
+    register_hook(HookType.CUSTOM, "two_required_args", two_required_args)
+
+    res = validate_hooks(HookType.CUSTOM)
+
+    valid_names = {item["name"] for item in res["valid_hooks"]}
+    invalid_names = {item["name"] for item in res["invalid_hooks"]}
+    assert {"single_context", "context_with_default", "context_with_varargs"} <= valid_names
+    assert "two_required_args" in invalid_names
+    assert res["valid"] is False
+
+
 def test_execute_hooks_with_fallback_platform_failure_falls_back_to_global() -> None:
     """HOOK-008: Platform failure falls back to global."""
 


### PR DESCRIPTION
## Summary
- Align validate_hooks signature validation with execute_hooks one-context call convention.
- Add regression coverage for rejecting two-required-argument hooks while preserving callable single-context/default/varargs signatures.

## Validation
- make format
- python -m pytest tests/test_hooks.py -k validate_hooks -q
- python -m pytest tests/test_hooks.py tests/blackbox/test_hooks.py -q
- python -m pytest tests/blackbox/test_project_builder.py -k 'hook or build_005 or build_006 or build_007' -q
- python -m pytest tests/whitebox/plugins/test_project_builder.py -k 'hook or build_005 or build_006 or build_007' -q

Closes #128