### PR TITLE
TASK-132: fix board_new projects.json board_path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.13"
+version = "0.2.14"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/plugins/project_manager.py
+++ b/src/plugins/project_manager.py
@@ -484,12 +484,19 @@ def board_new(env: Dict, projects_info: Dict, board_name: str) -> bool:
         with open(ini_path, "w", encoding="utf-8") as ini_file:
             ini_file.writelines(ini_lines)
 
+        root_path = env.get("root_path")
+        if not isinstance(root_path, str) or not root_path.strip():
+            if os.path.basename(projects_path) == "projects":
+                root_path = os.path.dirname(projects_path)
+            else:
+                root_path = projects_path
+        root_path = os.path.abspath(root_path)
         try:
-            board_path_rel = os.path.relpath(board_path, projects_path)
+            board_path_rel = os.path.relpath(board_path, root_path)
         except ValueError:
-            board_path_rel = board_name
+            board_path_rel = os.path.join(os.path.basename(projects_path), board_name)
         if os.path.isabs(board_path_rel):
-            board_path_rel = board_name
+            board_path_rel = os.path.join(os.path.basename(projects_path), board_name)
 
         board_metadata = {
             "board_name": board_name,

--- a/tests/blackbox/test_project_manager.py
+++ b/tests/blackbox/test_project_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 from configparser import ConfigParser
@@ -25,6 +26,10 @@ def test_pm_001_board_new_with_template(empty_workspace: Path) -> None:
     po_dir = board_dir / "po"
     assert ini_path.exists()
     assert po_dir.exists()
+    projects_json = board_dir / "projects.json"
+    data = json.loads(projects_json.read_text(encoding="utf-8"))
+    assert Path(data["board_path"]).is_absolute() is False
+    assert data["board_path"] == str(Path("projects") / "boardTest")
 
     run_cli(["project_new", "app1"], cwd=empty_workspace)
     po_list_result = run_cli(["po_list", "app1", "--short"], cwd=empty_workspace)

--- a/tests/blackbox/test_project_manager.py
+++ b/tests/blackbox/test_project_manager.py
@@ -56,9 +56,15 @@ def test_pm_002_board_new_without_template(workspace_a: Path) -> None:
         shutil.rmtree(template_dir)
     result = run_cli(["board_new", "boardNoTpl"], cwd=workspace_a)
     assert result.returncode == 0
-    ini_path = workspace_a / "projects" / "boardNoTpl" / "boardNoTpl.ini"
+    board_dir = workspace_a / "projects" / "boardNoTpl"
+    ini_path = board_dir / "boardNoTpl.ini"
     assert ini_path.exists()
-    assert (workspace_a / "projects" / "boardNoTpl" / "po" / "po_template" / "patches").exists()
+    assert (board_dir / "po" / "po_template" / "patches").exists()
+
+    projects_json = board_dir / "projects.json"
+    data = json.loads(projects_json.read_text(encoding="utf-8"))
+    assert Path(data["board_path"]).is_absolute() is False
+    assert data["board_path"] == str(Path("projects") / "boardNoTpl")
 
 
 def test_pm_003_board_new_invalid_names(workspace_a: Path) -> None:

--- a/tests/whitebox/plugins/test_project_manager.py
+++ b/tests/whitebox/plugins/test_project_manager.py
@@ -6,6 +6,7 @@ import configparser
 import json
 import os
 import sys
+from pathlib import Path
 
 
 class TestProjectNew:
@@ -1644,14 +1645,16 @@ class TestBoardNew:
     def test_board_new_creates_expected_structure(self, tmp_path):
         """PM-002: board_new succeeds without template (default structure)."""
 
-        env = {"projects_path": str(tmp_path)}
+        root = tmp_path
+        projects_path = root / "projects"
+        env = {"root_path": str(root), "projects_path": str(projects_path)}
         projects_info = {}
         board_name = "board_alpha"
 
         result = self.ProjectManager.board_new(env, projects_info, board_name)
 
         assert result is True
-        board_path = tmp_path / board_name
+        board_path = projects_path / board_name
         assert board_path.is_dir()
         assert (board_path / "po").is_dir()
         assert (board_path / "po" / "po_template").is_dir()
@@ -1667,7 +1670,8 @@ class TestBoardNew:
         assert projects_json_path.is_file()
         metadata = json.loads(projects_json_path.read_text(encoding="utf-8"))
         assert metadata["board_name"] == board_name
-        assert metadata["board_path"] == board_name
+        assert Path(metadata["board_path"]).is_absolute() is False
+        assert metadata["board_path"] == str(Path("projects") / board_name)
         assert metadata["projects"] == []
 
     def test_board_new_uses_template_when_available(self, tmp_path):


### PR DESCRIPTION
## Summary
- Fix board_new initial projects.json metadata to use the same root-relative board_path format as project loading.
- Add a blackbox regression assertion for board_new metadata.

## Verification
- make format
- python3 -m pytest -o addopts='' tests/blackbox/test_project_manager.py::test_pm_001_board_new_with_template tests/blackbox/test_project_manager.py::test_pm_002_board_new_without_template tests/blackbox/test_config.py::test_cfg_010_projects_json_written tests/whitebox/plugins/test_project_manager.py::TestBoardNew::test_board_new_creates_expected_structure
- python3 -m pytest -o addopts='' tests/blackbox/test_project_manager.py tests/blackbox/test_config.py tests/whitebox/plugins/test_project_manager.py::TestBoardNew tests/whitebox/test_main.py::TestLoadAllProjects::test_load_all_projects_writes_projects_json_per_board