### PR TITLE
TASK-138: refresh test document commands

### DIFF
--- a/docs/en/development/testing.md
+++ b/docs/en/development/testing.md
@@ -63,7 +63,7 @@ tests/
 ├── test_main.py              # Main application tests
 ├── test_log_manager.py       # Logging functionality tests
 ├── test_profiler.py          # Profiling functionality tests
-├── test_utils.py             # Utility function tests
+├── whitebox/test_utils.py    # Utility function tests
 ├── projects/                 # Test project configurations
 │   ├── board01/
 │   │   ├── board01.ini
@@ -105,7 +105,7 @@ tests/
 pytest
 
 # Run specific test file
-pytest tests/test_utils.py
+pytest tests/whitebox/test_utils.py
 
 # Run with verbose output
 pytest -v
@@ -224,7 +224,7 @@ def sample_project_config():
 
 **Automated Testing Before Commits**
 
-**Tools**: Git hooks (`hooks/pre-commit`)
+**Tools**: Git hooks (`git-hooks/pre-commit`)
 
 **Procedures**:
 - Run unit tests
@@ -235,14 +235,14 @@ def sample_project_config():
 **Configuration**:
 ```bash
 # Install hooks
-./hooks/install_hooks.sh
+./git-hooks/install_hooks.sh
 ```
 
 ### 2. Pre-push Testing
 
 **Comprehensive Testing Before Push**
 
-**Tools**: Git hooks (`hooks/pre-push`)
+**Tools**: Local pytest commands and GitHub Actions
 
 **Procedures**:
 - Full test suite execution
@@ -428,7 +428,7 @@ pytest tests/ -m "performance"
 pytest -v -s
 
 # Run single test
-pytest tests/test_utils.py::test_specific_function
+pytest tests/whitebox/test_utils.py::TestPathFromRoot::test_path_from_root_single_arg
 
 # Run with pdb
 pytest --pdb
@@ -442,7 +442,7 @@ pytest --pdb
 ./setup_venv.sh
 
 # Install test dependencies
-pip install -r requirements-dev.txt
+pip install -e ".[dev]"
 
 # Verify test environment
 pytest --collect-only
@@ -498,4 +498,4 @@ pytest --collect-only
 - Mutation testing
 - Property-based testing
 - Contract testing
-- Chaos engineering 
+- Chaos engineering

--- a/docs/zh/development/testing.md
+++ b/docs/zh/development/testing.md
@@ -63,7 +63,7 @@ tests/
 ├── test_main.py              # 主应用程序测试
 ├── test_log_manager.py       # 日志功能测试
 ├── test_profiler.py          # 性能分析功能测试
-├── test_utils.py             # 工具函数测试
+├── whitebox/test_utils.py    # 工具函数测试
 ├── projects/                 # 测试项目配置
 │   ├── board01/
 │   │   ├── board01.ini
@@ -105,7 +105,7 @@ tests/
 pytest
 
 # 运行特定测试文件
-pytest tests/test_utils.py
+pytest tests/whitebox/test_utils.py
 
 # 运行详细输出
 pytest -v
@@ -224,7 +224,7 @@ def sample_project_config():
 
 **提交前的自动化测试**
 
-**工具**: Git 钩子 (`hooks/pre-commit`)
+**工具**: Git 钩子 (`git-hooks/pre-commit`)
 
 **程序**:
 - 运行单元测试
@@ -235,14 +235,14 @@ def sample_project_config():
 **配置**:
 ```bash
 # 安装钩子
-./hooks/install_hooks.sh
+./git-hooks/install_hooks.sh
 ```
 
 ### 2. 预推送测试
 
 **推送前的综合测试**
 
-**工具**: Git 钩子 (`hooks/pre-push`)
+**工具**: 本地 pytest 命令和 GitHub Actions
 
 **程序**:
 - 完整测试套件执行
@@ -428,7 +428,7 @@ pytest tests/ -m "performance"
 pytest -v -s
 
 # 运行单个测试
-pytest tests/test_utils.py::test_specific_function
+pytest tests/whitebox/test_utils.py::TestPathFromRoot::test_path_from_root_single_arg
 
 # 运行 pdb
 pytest --pdb
@@ -442,7 +442,7 @@ pytest --pdb
 ./setup_venv.sh
 
 # 安装测试依赖
-pip install -r requirements-dev.txt
+pip install -e ".[dev]"
 
 # 验证测试环境
 pytest --collect-only

--- a/tests/whitebox/test_testing_docs_commands.py
+++ b/tests/whitebox/test_testing_docs_commands.py
@@ -1,0 +1,39 @@
+"""Regression tests for testing documentation command references."""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTING_DOCS = (
+    REPO_ROOT / "docs/en/development/testing.md",
+    REPO_ROOT / "docs/zh/development/testing.md",
+)
+PATH_REFERENCE_PATTERN = re.compile(
+    r"(?<![\w/.-])(?:\./)?(?:git-hooks|hooks|tests)/[A-Za-z0-9_./:-]+|requirements-[A-Za-z0-9_.-]+\.txt"
+)
+BASH_BLOCK_PATTERN = re.compile(r"```bash\n(?P<body>.*?)\n```", re.DOTALL)
+HOOK_TOOL_PATTERN = re.compile(r"`(?P<path>(?:\./)?hooks/[A-Za-z0-9_./:-]+)`")
+
+
+def _command_reference_text(markdown: str) -> str:
+    command_blocks = [match.group("body") for match in BASH_BLOCK_PATTERN.finditer(markdown)]
+    hook_tools = [match.group("path") for match in HOOK_TOOL_PATTERN.finditer(markdown)]
+    return "\n".join(command_blocks + hook_tools)
+
+
+def _referenced_repo_paths(markdown: str):
+    for match in PATH_REFERENCE_PATTERN.finditer(_command_reference_text(markdown)):
+        reference = match.group(0).split("::", 1)[0].rstrip("`.,;)")
+        yield reference[2:] if reference.startswith("./") else reference
+
+
+def test_testing_docs_only_reference_existing_repo_paths():
+    """Testing docs should not send contributors to removed files or directories."""
+    missing = []
+    for doc_path in TESTING_DOCS:
+        markdown = doc_path.read_text(encoding="utf-8")
+        for reference in _referenced_repo_paths(markdown):
+            if not (REPO_ROOT / reference).exists():
+                missing.append(f"{doc_path.relative_to(REPO_ROOT)} -> {reference}")
+
+    assert not missing, "Missing testing doc command paths:\n" + "\n".join(missing)


### PR DESCRIPTION
## Summary

Fixes #138.

This refreshes the English and Chinese testing documentation so the install and run commands point at files that exist in the current repository layout. The stale hook path now uses `git-hooks/install_hooks.sh`, the old `requirements-dev.txt` install command now uses the project dev extra, and the sample pytest commands now point at `tests/whitebox/test_utils.py`.

A focused regression test was added to validate command/path references in both testing documents so removed files and directories do not reappear in those command examples.

## Verification

- `make format`
- `python -m pytest -o addopts='' tests/whitebox/test_testing_docs_commands.py tests/whitebox/test_utils.py::TestPathFromRoot::test_path_from_root_single_arg tests/whitebox/test_bump_version_script.py::test_release_code_path_detection -q`
- `git diff --check -- docs/en/development/testing.md docs/zh/development/testing.md tests/whitebox/test_testing_docs_commands.py`