### PR TITLE
TASK-145: avoid config-load projects json writes

### DIFF
--- a/docs/test_cases_en.md
+++ b/docs/test_cases_en.md
@@ -107,7 +107,7 @@
 | CFG-007 | Project Scan | Duplicate keys in section cause skip | Put duplicate `PROJECT_NAME` in one section, including mixed-case aliases such as `PROJECT_NAME` and `project_name` | 1. Run `python -m src po_list projA`.<br>2. Check logs.<br>3. Run `python -m src doctor --json`. | Error logs duplicate key; that board is skipped. Doctor JSON reports the duplicate key in `ini_duplicate_keys`. | P1 | Negative |
 | CFG-008 | Config Merge | common + parent + child merge with PO concat | Dataset A completed | 1. Ensure `projA` and `projA-sub` exist.<br>2. Run `python -m src po_list projA-sub`.<br>3. Inspect effective config in logs. | Child inherits common and parent; `PROJECT_PO_CONFIG` is concatenated with space. | P1 | Functional |
 | CFG-009 | Relationships | parent/children built correctly | Dataset A completed | 1. Inspect `projects_info` in logs. | `projA-sub` parent is `projA`; `projA` children includes `projA-sub`. | P2 | Functional |
-| CFG-010 | Index Write | projects.json written per board | Dataset A completed | 1. Run a command (e.g., `python -m src po_list projA`).<br>2. Check `projects/boardA/projects.json`. | File contains board_name, last_updated, and projects list with configs. | P1 | Functional |
+| CFG-010 | Index Write | Read-only project load does not rewrite board projects.json | Dataset A completed | 1. Ensure `projects/boardA/projects.json` is absent or capture its exact contents.<br>2. Run a read-only command (e.g., `python -m src po_list projA`).<br>3. Check `projects/boardA/projects.json`. | Read-only commands do not create or rewrite the board metadata file; explicit project write paths may refresh it with relative paths only. | P1 | Functional |
 
 ## 3. Repository Discovery (_find_repositories)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.14"
+version = "0.2.15"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -104,9 +104,81 @@ def _load_common_config(projects_path):
     return common_configs, po_configs
 
 
+def _write_projects_info_to_boards(projects_info, projects_path):
+    """
+    Write project information to board directories.
+
+    Args:
+        projects_info (dict): Dictionary containing project information
+        projects_path (str): Path to projects directory
+    """
+    try:
+        root_path = os.path.abspath(os.path.join(projects_path, os.pardir))
+
+        def _to_relpath(path_value: Optional[str]) -> Optional[str]:
+            if not path_value:
+                return path_value
+            try:
+                rel = os.path.relpath(path_value, root_path)
+            except ValueError:
+                rel = os.path.basename(path_value)
+            # Fail closed: never persist absolute paths in caches.
+            if os.path.isabs(rel):
+                rel = os.path.basename(rel)
+            return rel
+
+        # Group projects by board_name
+        board_projects = {}
+        for project_name, project_info in projects_info.items():
+            board_name = project_info.get("board_name")
+            if not board_name:
+                continue
+            if board_name not in board_projects:
+                board_projects[board_name] = []
+            board_projects[board_name].append(
+                {
+                    "project_name": project_name,
+                    "config": project_info.get("config", {}),
+                    "parent": project_info.get("parent"),
+                    "children": project_info.get("children", []),
+                    "ini_file": project_info.get("ini_file"),
+                }
+            )
+
+        # Write project information to each board directory
+        for board_name, projects in board_projects.items():
+            board_path = os.path.join(projects_path, board_name)
+            if not os.path.exists(board_path):
+                log.warning("Board directory does not exist: %s", board_path)
+                continue
+
+            # Prepare project data for JSON output (store relative paths only).
+            board_projects_out = []
+            for project in projects:
+                item = dict(project)
+                item["ini_file"] = _to_relpath(item.get("ini_file"))
+                board_projects_out.append(item)
+
+            project_data = {
+                "board_name": board_name,
+                "board_path": _to_relpath(board_path),
+                "last_updated": datetime.now().isoformat(),
+                "projects": board_projects_out,
+            }
+
+            projects_json_path = os.path.join(board_path, "projects.json")
+            with open(projects_json_path, "w", encoding="utf-8") as f:
+                json.dump(project_data, f, indent=2, ensure_ascii=False)
+
+            log.debug("Project information written to: %s", projects_json_path)
+
+    except (OSError, IOError, ValueError) as e:
+        log.error("Failed to write project information to board directories: %s", e)
+
+
 @func_time
 @func_cprofile
-def _load_all_projects(projects_path, common_configs):
+def _load_all_projects(projects_path, common_configs, write_projects_index=False):
     exclude_dirs = {"scripts", "common", "template", ".cache", ".git"}
     if not os.path.exists(projects_path):
         log.warning("projects directory does not exist: '%s'", projects_path)
@@ -230,80 +302,8 @@ def _load_all_projects(projects_path, common_configs):
             continue
         project_info["config"] = merge_config(project)
 
-    # Write project information to board directories
-    def __write_projects_info_to_boards(projects_info, projects_path):
-        """
-        Write project information to board directories.
-
-        Args:
-            projects_info (dict): Dictionary containing project information
-            projects_path (str): Path to projects directory
-        """
-        try:
-            root_path = os.path.abspath(os.path.join(projects_path, os.pardir))
-
-            def _to_relpath(path_value: Optional[str]) -> Optional[str]:
-                if not path_value:
-                    return path_value
-                try:
-                    rel = os.path.relpath(path_value, root_path)
-                except ValueError:
-                    rel = os.path.basename(path_value)
-                # Fail closed: never persist absolute paths in caches.
-                if os.path.isabs(rel):
-                    rel = os.path.basename(rel)
-                return rel
-
-            # Group projects by board_name
-            board_projects = {}
-            for project_name, project_info in projects_info.items():
-                board_name = project_info.get("board_name")
-                if not board_name:
-                    continue
-                if board_name not in board_projects:
-                    board_projects[board_name] = []
-                board_projects[board_name].append(
-                    {
-                        "project_name": project_name,
-                        "config": project_info.get("config", {}),
-                        "parent": project_info.get("parent"),
-                        "children": project_info.get("children", []),
-                        "ini_file": project_info.get("ini_file"),
-                    }
-                )
-
-            # Write project information to each board directory
-            for board_name, projects in board_projects.items():
-                board_path = os.path.join(projects_path, board_name)
-                if not os.path.exists(board_path):
-                    log.warning("Board directory does not exist: %s", board_path)
-                    continue
-
-                # Prepare project data for JSON output (store relative paths only).
-                board_projects_out = []
-                for project in projects:
-                    item = dict(project)
-                    item["ini_file"] = _to_relpath(item.get("ini_file"))
-                    board_projects_out.append(item)
-
-                project_data = {
-                    "board_name": board_name,
-                    "board_path": _to_relpath(board_path),
-                    "last_updated": datetime.now().isoformat(),
-                    "projects": board_projects_out,
-                }
-
-                # Write to projects.json in board directory
-                projects_json_path = os.path.join(board_path, "projects.json")
-                with open(projects_json_path, "w", encoding="utf-8") as f:
-                    json.dump(project_data, f, indent=2, ensure_ascii=False)
-
-                log.debug("Project information written to: %s", projects_json_path)
-
-        except (OSError, IOError, ValueError) as e:
-            log.error("Failed to write project information to board directories: %s", e)
-
-    __write_projects_info_to_boards(projects_info, projects_path)
+    if write_projects_index:
+        _write_projects_info_to_boards(projects_info, projects_path)
 
     return projects_info
 
@@ -1099,6 +1099,16 @@ def main():
             if result is False:
                 log.error("Operation '%s' failed", operate)
                 sys.exit(1)
+            if operate in {"project_new", "project_del"}:
+                try:
+                    _load_all_projects(
+                        env["projects_path"],
+                        common_configs,
+                        write_projects_index=True,
+                    )
+                except ValueError as err:
+                    log.error("Failed to refresh project index after '%s': %s", operate, err)
+                    sys.exit(1)
         except TypeError as e:
             log.error("Failed to call operation '%s': %s", operate, e)
             sys.exit(1)

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1099,7 +1099,7 @@ def main():
             if result is False:
                 log.error("Operation '%s' failed", operate)
                 sys.exit(1)
-            if operate in {"project_new", "project_del"}:
+            if operate in {"project_new", "project_del", "po_del"}:
                 try:
                     _load_all_projects(
                         env["projects_path"],

--- a/tests/blackbox/test_config.py
+++ b/tests/blackbox/test_config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from .conftest import run_cli
@@ -13,12 +12,6 @@ def _read_latest_log(root: Path) -> str:
     if not log_path.exists():
         return ""
     return log_path.read_text(encoding="utf-8")
-
-
-def _load_projects_json(root: Path) -> dict:
-    projects_json = root / "projects" / "boardA" / "projects.json"
-    assert projects_json.exists()
-    return json.loads(projects_json.read_text(encoding="utf-8"))
 
 
 def test_cfg_001_missing_common_ini(workspace_a: Path) -> None:
@@ -46,9 +39,8 @@ def test_cfg_003_inline_comment_stripped(workspace_a: Path) -> None:
         updated = text + "\n[common]\nINLINE_KEY = value # comment\n"
     common_ini.write_text(updated, encoding="utf-8")
     _ = run_cli(["po_list", "projA"], cwd=workspace_a)
-    data = _load_projects_json(workspace_a)
-    proj = next(item for item in data["projects"] if item["project_name"] == "projA")
-    assert proj["config"]["INLINE_KEY"] == "value"
+    log_text = _read_latest_log(workspace_a)
+    assert '"INLINE_KEY": "value"' in log_text
 
 
 def test_cfg_004_projects_dir_missing(workspace_a: Path) -> None:
@@ -91,30 +83,20 @@ def test_cfg_007_duplicate_key_skips_board(workspace_a: Path) -> None:
 
 def test_cfg_008_config_inheritance_po_concat(workspace_a: Path) -> None:
     _ = run_cli(["po_list", "projA-sub"], cwd=workspace_a)
-    data = _load_projects_json(workspace_a)
-    proj = next(item for item in data["projects"] if item["project_name"] == "projA-sub")
-    assert "PROJECT_PO_CONFIG" in proj["config"]
-    assert "po_base" in proj["config"]["PROJECT_PO_CONFIG"]
-    assert "po_sub" in proj["config"]["PROJECT_PO_CONFIG"]
+    log_text = _read_latest_log(workspace_a)
+    assert '"PROJECT_PO_CONFIG":' in log_text
+    assert "po_base" in log_text
+    assert "po_sub" in log_text
 
 
 def test_cfg_009_parent_children_relationship(workspace_a: Path) -> None:
     _ = run_cli(["po_list", "projA"], cwd=workspace_a)
-    data = _load_projects_json(workspace_a)
-    proj_a = next(item for item in data["projects"] if item["project_name"] == "projA")
-    proj_sub = next(item for item in data["projects"] if item["project_name"] == "projA-sub")
-    assert proj_sub["parent"] == "projA"
-    assert "projA-sub" in proj_a["children"]
+    log_text = _read_latest_log(workspace_a)
+    assert '"parent": "projA"' in log_text
+    assert '"projA-sub"' in log_text
 
 
-def test_cfg_010_projects_json_written(workspace_a: Path) -> None:
+def test_cfg_010_readonly_command_does_not_write_projects_json(workspace_a: Path) -> None:
     _ = run_cli(["po_list", "projA"], cwd=workspace_a)
     projects_json = workspace_a / "projects" / "boardA" / "projects.json"
-    assert projects_json.exists()
-    data = json.loads(projects_json.read_text(encoding="utf-8"))
-    assert Path(data["board_path"]).is_absolute() is False
-    assert data["board_path"] == str(Path("projects") / "boardA")
-    for project in data.get("projects", []):
-        ini_file = project.get("ini_file")
-        if ini_file:
-            assert Path(ini_file).is_absolute() is False
+    assert not projects_json.exists()

--- a/tests/blackbox/test_patch_override.py
+++ b/tests/blackbox/test_patch_override.py
@@ -426,6 +426,24 @@ def test_po_021_po_del_remove_config(workspace_a: Path) -> None:
     assert not (workspace_a / "projects" / "boardA" / "po" / "po_base").exists()
 
 
+def test_po_021b_po_del_refreshes_existing_projects_json(workspace_a: Path) -> None:
+    _remove_common_po_config(workspace_a)
+    projects_path = workspace_a / "projects"
+    common_configs, _ = _load_common_config(str(projects_path))
+    _load_all_projects(str(projects_path), common_configs, write_projects_index=True)
+
+    projects_json = projects_path / "boardA" / "projects.json"
+    before = json.loads(projects_json.read_text(encoding="utf-8"))
+    assert any("po_base" in project["config"].get("PROJECT_PO_CONFIG", "").split() for project in before["projects"])
+
+    result = run_cli(["po_del", "projA", "po_base", "--force"], cwd=workspace_a)
+
+    assert result.returncode == 0
+    after = json.loads(projects_json.read_text(encoding="utf-8"))
+    for project in after["projects"]:
+        assert "po_base" not in project["config"].get("PROJECT_PO_CONFIG", "").split()
+
+
 def test_po_022_po_del_cancel(workspace_a: Path) -> None:
     run_cli(["po_new", "projA", "po_cancel", "--force"], cwd=workspace_a)
     result = run_cli(["po_del", "projA", "po_cancel"], cwd=workspace_a, check=False)

--- a/tests/blackbox/test_project_manager.py
+++ b/tests/blackbox/test_project_manager.py
@@ -113,6 +113,9 @@ def test_pm_009_project_new_append_section(workspace_a: Path) -> None:
     ini_path = workspace_a / "projects" / "boardA" / "boardA.ini"
     text = ini_path.read_text(encoding="utf-8")
     assert "[projA-new]" in text
+    projects_json = workspace_a / "projects" / "boardA" / "projects.json"
+    data = json.loads(projects_json.read_text(encoding="utf-8"))
+    assert any(project.get("project_name") == "projA-new" for project in data["projects"])
 
 
 def test_pm_009_project_new_creates_first_top_level_project(empty_workspace: Path) -> None:

--- a/tests/whitebox/test_main.py
+++ b/tests/whitebox/test_main.py
@@ -495,6 +495,33 @@ PROJECT_NAME=project2
         assert os.path.join("board01", "board01.ini") in message
         assert os.path.join("board02", "board02.ini") in message
 
+    def test_load_all_projects_does_not_rewrite_projects_json_by_default(self):
+        """Read-only project loading must not rewrite existing board metadata."""
+        projects_path = self._create_temp_projects_structure()
+
+        ini_content = """[testproject]
+PROJECT_NAME=test_project
+"""
+        board_path, _ini_file = self._create_board_structure(projects_path, "board01", ini_content)
+        projects_json = os.path.join(board_path, "projects.json")
+        original_json = json.dumps(
+            {
+                "board_name": "board01",
+                "board_path": "projects/board01",
+                "last_updated": "keep-this-timestamp",
+                "projects": [],
+            },
+            indent=2,
+        )
+        with open(projects_json, "w", encoding="utf-8") as f:
+            f.write(original_json)
+
+        result = self._load_projects_with_config(projects_path)
+
+        assert "testproject" in result
+        with open(projects_json, "r", encoding="utf-8") as f:
+            assert f.read() == original_json
+
     def test_load_all_projects_invalid_projects_handling(self):
         """Test handling of invalid projects."""
         projects_path = self._create_temp_projects_structure()
@@ -616,8 +643,8 @@ PROJECT_NAME=test_project
         # Should not inherit any common settings since [common] section is missing
         assert "SOME_SETTING" not in project_info["config"]
 
-    def test_load_all_projects_writes_projects_json_per_board(self):
-        """CFG-010: projects.json written per board directory."""
+    def test_load_all_projects_writes_projects_json_per_board_when_explicit(self):
+        """Explicit project index refresh writes projects.json per board directory."""
         projects_path = self._create_temp_projects_structure()
 
         ini_content = """[testproject]
@@ -626,7 +653,8 @@ PROJECT_PLATFORM=test_platform
 """
         board_path, _ini_file = self._create_board_structure(projects_path, "board01", ini_content)
 
-        result = self._load_projects_with_config(projects_path)
+        common_configs, _ = self._load_common_config(projects_path)
+        result = self._load_all_projects(projects_path, common_configs, write_projects_index=True)
         assert "testproject" in result
 
         projects_json = os.path.join(board_path, "projects.json")


### PR DESCRIPTION
## Summary

Fixes #145.

- Make `_load_all_projects()` read-only by default so configuration loading does not create or rewrite `projects/<board>/projects.json`.
- Keep board project metadata writing behind an explicit refresh path, and refresh it after successful `project_new` / `project_del` operations.
- Update CFG-010 coverage so read-only commands assert no board metadata write, while explicit write-path tests still cover metadata generation with relative paths.

## Verification

- `make format`
- `python -m pytest -o addopts='' tests/whitebox/test_main.py::TestLoadAllProjects::test_load_all_projects_does_not_rewrite_projects_json_by_default`
- `python -m pytest -o addopts='' tests/whitebox/test_main.py::TestLoadAllProjects`
- `python -m pytest -o addopts='' tests/blackbox/test_config.py tests/blackbox/test_project_manager.py`
- `python -m pytest -o addopts='' tests/blackbox/test_patch_override.py tests/blackbox/test_project_builder.py tests/blackbox/test_sample_projects_metadata.py`
- `make test`
- `python -m src po_list board01-project01 --short`
- `git diff -- projects/board01/projects.json`