### PR TITLE
TASK-152: avoid duplicate global hook fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.15"
+version = "0.2.16"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/hooks/executor.py
+++ b/src/hooks/executor.py
@@ -3,11 +3,63 @@ Hook execution engine for extensible project building operations.
 """
 
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from src.hooks.registry import HookType, get_hooks
 
 log = logging.getLogger(__name__)
+
+
+def _hook_key(hook_info: Dict[str, Any]) -> Tuple[Optional[str], str]:
+    """Return a stable key for a registered hook within one execution pass."""
+    return (hook_info.get("platform"), str(hook_info["name"]))
+
+
+def _execute_hook_list(
+    hook_type: Union[str, "HookType"],
+    hooks: List[Dict[str, Any]],
+    context: Dict[str, Any],
+    stop_on_error: bool = False,
+    executed_hooks: Optional[Set[Tuple[Optional[str], str]]] = None,
+) -> Tuple[bool, Optional[Dict[str, Any]]]:
+    """Execute hook info dictionaries and return the first failing hook."""
+    if not hooks:
+        log.debug("No hooks found for type '%s'", hook_type)
+        return True, None
+
+    log.debug("Executing %d hooks for type '%s'", len(hooks), hook_type)
+
+    for hook_info in hooks:
+        hook_name = hook_info["name"]
+        hook_func = hook_info["func"]
+        hook_priority = hook_info["priority"]
+
+        if executed_hooks is not None:
+            executed_hooks.add(_hook_key(hook_info))
+
+        try:
+            log.debug("Executing hook '%s' with priority %d", hook_name, hook_priority.value)
+
+            # Execute the hook function
+            hook_result = hook_func(context)
+
+            # Check if hook returned False (failure)
+            if hook_result is False:
+                log.error("Hook '%s' returned False, indicating failure", hook_name)
+                return False, hook_info
+
+            log.debug("Hook '%s' executed successfully", hook_name)
+
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            error_msg = f"Error executing hook '{hook_name}': {str(e)}"
+            log.error(error_msg)
+
+            if stop_on_error:
+                log.error("Stopping hook execution due to error in '%s'", hook_name)
+                return False, hook_info
+
+    log.debug("All hooks for type '%s' executed successfully", hook_type)
+    return True, None
 
 
 def execute_hooks(
@@ -29,41 +81,8 @@ def execute_hooks(
         True if all hooks executed successfully, False otherwise
     """
     hooks = get_hooks(hook_type, platform)
-
-    if not hooks:
-        log.debug("No hooks found for type '%s'", hook_type)
-        return True
-
-    log.debug("Executing %d hooks for type '%s'", len(hooks), hook_type)
-
-    for hook_info in hooks:
-        hook_name = hook_info["name"]
-        hook_func = hook_info["func"]
-        hook_priority = hook_info["priority"]
-
-        try:
-            log.debug("Executing hook '%s' with priority %d", hook_name, hook_priority.value)
-
-            # Execute the hook function
-            hook_result = hook_func(context)
-
-            # Check if hook returned False (failure)
-            if hook_result is False:
-                log.error("Hook '%s' returned False, indicating failure", hook_name)
-                return False
-
-            log.debug("Hook '%s' executed successfully", hook_name)
-
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            error_msg = f"Error executing hook '{hook_name}': {str(e)}"
-            log.error(error_msg)
-
-            if stop_on_error:
-                log.error("Stopping hook execution due to error in '%s'", hook_name)
-                return False
-
-    log.debug("All hooks for type '%s' executed successfully", hook_type)
-    return True
+    result, _failed_hook = _execute_hook_list(hook_type, hooks, context, stop_on_error)
+    return result
 
 
 def execute_single_hook(
@@ -183,12 +202,21 @@ def execute_hooks_with_fallback(
     if not platform:
         return execute_hooks(hook_type, context, None)
 
-    # Try platform-specific hooks first
-    platform_result = execute_hooks(hook_type, context, platform)
+    # Try merged global/platform hooks first
+    executed_hooks: Set[Tuple[Optional[str], str]] = set()
+    platform_hooks = get_hooks(hook_type, platform)
+    platform_result, failed_hook = _execute_hook_list(hook_type, platform_hooks, context, executed_hooks=executed_hooks)
 
     if platform_result or not fallback_to_global:
         return platform_result
 
+    if failed_hook is not None and failed_hook.get("platform") is None:
+        return False
+
     # Fall back to global hooks
     log.info("Platform hooks failed for %s, falling back to global hooks", platform)
-    return execute_hooks(hook_type, context, None)
+    fallback_hooks = [hook for hook in get_hooks(hook_type, None) if _hook_key(hook) not in executed_hooks]
+    fallback_result, _failed_hook = _execute_hook_list(
+        hook_type, fallback_hooks, context, executed_hooks=executed_hooks
+    )
+    return fallback_result

--- a/tests/blackbox/test_hooks.py
+++ b/tests/blackbox/test_hooks.py
@@ -92,6 +92,17 @@ def test_hook_007_validate_hook_signature() -> None:
 
 
 def test_hook_008_fallback_to_global() -> None:
-    register_hook(HookType.BUILD, "platform_fail", lambda ctx: False, platform="platA")
-    register_hook(HookType.BUILD, "global_ok", lambda ctx: True)
+    calls = []
+
+    def global_ok(ctx):
+        calls.append("global")
+        return True
+
+    def platform_fail(ctx):
+        calls.append("platform")
+        return False
+
+    register_hook(HookType.BUILD, "platform_fail", platform_fail, platform="platA")
+    register_hook(HookType.BUILD, "global_ok", global_ok)
     assert execute_hooks_with_fallback(HookType.BUILD, {}, platform="platA") is True
+    assert calls == ["global", "platform"]

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -222,13 +222,16 @@ def test_validate_hooks_rejects_signatures_that_cannot_accept_context() -> None:
 
 def test_execute_hooks_with_fallback_platform_failure_falls_back_to_global() -> None:
     """HOOK-008: Platform failure falls back to global."""
+    calls: List[str] = []
 
     def plat(ctx: Dict[str, Any]) -> bool:
         _ = ctx
+        calls.append("plat")
         return False
 
     def glob(ctx: Dict[str, Any]) -> bool:
         _ = ctx
+        calls.append("glob")
         return True
 
     register_hook(HookType.BUILD, "plat", plat, platform="platA")
@@ -236,3 +239,4 @@ def test_execute_hooks_with_fallback_platform_failure_falls_back_to_global() -> 
 
     ok = execute_hooks_with_fallback(HookType.BUILD, context={}, platform="platA")
     assert ok is True
+    assert calls == ["glob", "plat"]

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -240,3 +240,31 @@ def test_execute_hooks_with_fallback_platform_failure_falls_back_to_global() -> 
     ok = execute_hooks_with_fallback(HookType.BUILD, context={}, platform="platA")
     assert ok is True
     assert calls == ["glob", "plat"]
+
+
+def test_execute_hooks_with_fallback_runs_unexecuted_global_hooks_after_platform_failure() -> None:
+    """HOOK-008: Platform failure falls back to unexecuted global hooks."""
+    calls: List[str] = []
+
+    def global_before(ctx: Dict[str, Any]) -> bool:
+        _ = ctx
+        calls.append("global_before")
+        return True
+
+    def platform_fail(ctx: Dict[str, Any]) -> bool:
+        _ = ctx
+        calls.append("platform")
+        return False
+
+    def global_after(ctx: Dict[str, Any]) -> bool:
+        _ = ctx
+        calls.append("global_after")
+        return True
+
+    register_hook(HookType.BUILD, "global_before", global_before, priority=HookPriority.HIGH)
+    register_hook(HookType.BUILD, "platform_fail", platform_fail, priority=HookPriority.NORMAL, platform="platA")
+    register_hook(HookType.BUILD, "global_after", global_after, priority=HookPriority.LOW)
+
+    ok = execute_hooks_with_fallback(HookType.BUILD, context={}, platform="platA")
+    assert ok is True
+    assert calls == ["global_before", "platform", "global_after"]


### PR DESCRIPTION
## Summary
- Add HOOK-008 regression coverage for duplicate global hook execution during platform fallback.
- Track hooks executed during the first pass so fallback only runs remaining global hooks.

## Verification
- make format
- python -m pytest -o addopts='' tests/test_hooks.py::test_execute_hooks_with_fallback_platform_failure_falls_back_to_global tests/blackbox/test_hooks.py::test_hook_008_fallback_to_global
- python -m pytest -o addopts='' tests/test_hooks.py tests/blackbox/test_hooks.py
- python -m pytest -o addopts='' tests/blackbox/test_project_builder.py tests/whitebox/plugins/test_project_builder.py
- make lint
- make test

Closes #152