### PR TITLE
TASK-155: snapshot gitfile repository heads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.16"
+version = "0.2.17"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/src/plugins/snapshot.py
+++ b/src/plugins/snapshot.py
@@ -13,7 +13,8 @@ from src.plugins.patch_override import parse_po_config
 
 
 def _repo_head_sha(repo_path: str) -> str:
-    if not os.path.isdir(os.path.join(repo_path, ".git")):
+    git_marker = os.path.join(repo_path, ".git")
+    if not (os.path.isdir(git_marker) or os.path.isfile(git_marker)):
         return ""
     result = subprocess.run(
         ["git", "rev-parse", "HEAD"],

--- a/src/plugins/snapshot.py
+++ b/src/plugins/snapshot.py
@@ -172,7 +172,17 @@ def snapshot_validate(
             drift["repos"].append({"name": name, "status": "missing"})
             continue
         current_head = _repo_head_sha(current_path)
-        if expected_head and current_head and expected_head != current_head:
+        if expected_head and not current_head:
+            drift["repos"].append(
+                {
+                    "name": name,
+                    "path": _safe_relpath(current_path, start=root_path),
+                    "expected_head": expected_head,
+                    "current_head": current_head,
+                    "status": "head_unavailable",
+                }
+            )
+        elif expected_head and current_head and expected_head != current_head:
             drift["repos"].append(
                 {
                     "name": name,
@@ -204,6 +214,8 @@ def snapshot_validate(
                 status = item.get("status")
                 if status == "missing":
                     print(f"- repo missing: {item.get('name')}")
+                elif status == "head_unavailable":
+                    print(f"- repo head unavailable: {item.get('name')} expected={item.get('expected_head')}")
                 elif status == "head_mismatch":
                     print(
                         f"- repo head mismatch: {item.get('name')} "

--- a/tests/whitebox/plugins/test_snapshot.py
+++ b/tests/whitebox/plugins/test_snapshot.py
@@ -119,3 +119,55 @@ class TestSnapshot:
         assert report["operation"] == "snapshot_validate"
         assert report["status"] == "drift"
         assert any(item.get("status") == "head_mismatch" for item in report["drift"]["repos"])
+
+    def test_snapshot_tracks_gitfile_repository_head_and_drift(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+
+        source_repo = tmp_path / "source"
+        source_repo.mkdir()
+        subprocess.run(["git", "init"], cwd=str(source_repo), check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=str(source_repo), check=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], cwd=str(source_repo), check=True)
+
+        (source_repo / "a.txt").write_text("base\n", encoding="utf-8")
+        subprocess.run(["git", "add", "a.txt"], cwd=str(source_repo), check=True)
+        subprocess.run(["git", "commit", "-m", "base"], cwd=str(source_repo), check=True)
+
+        linked_repo = tmp_path / "linked"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "linked-branch", str(linked_repo)],
+            cwd=str(source_repo),
+            check=True,
+        )
+        assert (linked_repo / ".git").is_file()
+
+        projects_root = tmp_path / "projects"
+        projects_root.mkdir(parents=True, exist_ok=True)
+        env = {
+            "root_path": str(tmp_path),
+            "projects_path": str(projects_root),
+            "repositories": [(str(linked_repo), "linked")],
+        }
+        projects_info = {
+            "projA": {
+                "board_name": "boardA",
+                "config": {"PROJECT_PO_CONFIG": "po1"},
+            }
+        }
+
+        snap_path = tmp_path / "snapshot.json"
+        assert self.snapshot_create(env, projects_info, "projA", out=str(snap_path)) is True
+        snapshot = json.loads(snap_path.read_text(encoding="utf-8"))
+        assert len(snapshot["repositories"][0]["head"]) == 40
+
+        (linked_repo / "a.txt").write_text("base\nchange\n", encoding="utf-8")
+        subprocess.run(["git", "add", "a.txt"], cwd=str(linked_repo), check=True)
+        subprocess.run(["git", "commit", "-m", "change"], cwd=str(linked_repo), check=True)
+
+        result = self.snapshot_validate(env, projects_info, str(snap_path), json=True)
+        assert result is False
+        report = json.loads(capsys.readouterr().out)
+        assert report["status"] == "drift"
+        assert any(
+            item.get("name") == "linked" and item.get("status") == "head_mismatch" for item in report["drift"]["repos"]
+        )

--- a/tests/whitebox/plugins/test_snapshot.py
+++ b/tests/whitebox/plugins/test_snapshot.py
@@ -171,3 +171,55 @@ class TestSnapshot:
         assert any(
             item.get("name") == "linked" and item.get("status") == "head_mismatch" for item in report["drift"]["repos"]
         )
+
+    def test_snapshot_validate_flags_unavailable_gitfile_head(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+
+        source_repo = tmp_path / "source"
+        source_repo.mkdir()
+        subprocess.run(["git", "init"], cwd=str(source_repo), check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=str(source_repo), check=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], cwd=str(source_repo), check=True)
+
+        (source_repo / "a.txt").write_text("base\n", encoding="utf-8")
+        subprocess.run(["git", "add", "a.txt"], cwd=str(source_repo), check=True)
+        subprocess.run(["git", "commit", "-m", "base"], cwd=str(source_repo), check=True)
+
+        linked_repo = tmp_path / "linked"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "linked-branch", str(linked_repo)],
+            cwd=str(source_repo),
+            check=True,
+        )
+        git_file = linked_repo / ".git"
+        assert git_file.is_file()
+
+        projects_root = tmp_path / "projects"
+        projects_root.mkdir(parents=True, exist_ok=True)
+        env = {
+            "root_path": str(tmp_path),
+            "projects_path": str(projects_root),
+            "repositories": [(str(linked_repo), "linked")],
+        }
+        projects_info = {
+            "projA": {
+                "board_name": "boardA",
+                "config": {"PROJECT_PO_CONFIG": "po1"},
+            }
+        }
+
+        snap_path = tmp_path / "snapshot.json"
+        assert self.snapshot_create(env, projects_info, "projA", out=str(snap_path)) is True
+        snapshot = json.loads(snap_path.read_text(encoding="utf-8"))
+        assert len(snapshot["repositories"][0]["head"]) == 40
+
+        git_file.write_text(f"gitdir: {tmp_path / 'missing-git-dir'}\n", encoding="utf-8")
+
+        result = self.snapshot_validate(env, projects_info, str(snap_path), json=True)
+        assert result is False
+        report = json.loads(capsys.readouterr().out)
+        assert report["status"] == "drift"
+        assert any(
+            item.get("name") == "linked" and item.get("status") == "head_unavailable"
+            for item in report["drift"]["repos"]
+        )


### PR DESCRIPTION
## Summary
- Support repositories whose `.git` marker is a file when reading snapshot HEAD SHAs.
- Add a regression test using a Git worktree to ensure snapshot creation records the HEAD and validation reports `head_mismatch` after drift.

## Root Cause
`_repo_head_sha()` only accepted `.git` directories before running `git rev-parse HEAD`. Valid worktree and submodule-style repositories use a `.git` file that points at the real gitdir, so snapshots recorded an empty head and validation skipped the comparison.

## Verification
- `make format`
- `python -m pytest -o addopts='' tests/whitebox/plugins/test_snapshot.py -q`
- `make test`

Closes #155