### PR TITLE
TASK-ci: allow first validate before version bump

### DIFF
--- a/.github/scripts/validate_release_version.py
+++ b/.github/scripts/validate_release_version.py
@@ -16,6 +16,8 @@ if str(SCRIPT_DIR) not in sys.path:
 
 import bump_version as version_helper  # isort: skip
 
+AUTO_BUMP_PR_ACTIONS = frozenset({"opened", "reopened", "synchronize", "ready_for_review"})
+
 
 @dataclass(frozen=True)
 class ValidationResult:
@@ -53,6 +55,7 @@ def validate_release_version(
     head_branch: str,
     has_release_code_changes: bool,
     event_name: str,
+    event_action: str,
 ) -> ValidationResult:
     """Validate the version relationship between the base and PR head."""
     bump_part = bump_part_for_branch(head_branch)
@@ -78,7 +81,7 @@ def validate_release_version(
             expected_version=expected_version,
         )
 
-    if event_name == "pull_request" and head_version == base_version:
+    if event_name == "pull_request" and event_action in AUTO_BUMP_PR_ACTIONS and head_version == base_version:
         return ValidationResult(
             True,
             (
@@ -123,6 +126,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=os.environ.get("GITHUB_EVENT_NAME", ""),
         help="GitHub event name, for example pull_request or workflow_dispatch",
     )
+    parser.add_argument(
+        "--event-action",
+        default=os.environ.get("GITHUB_EVENT_ACTION", ""),
+        help="GitHub pull_request action, for example opened, synchronize, reopened, or edited",
+    )
     parser.add_argument("--file", default="pyproject.toml", help="Path to the working tree pyproject.toml")
     return parser
 
@@ -140,6 +148,7 @@ def main() -> int:
         head_branch=args.head_branch,
         has_release_code_changes=has_release_changes,
         event_name=args.event_name,
+        event_action=args.event_action,
     )
     if result.valid:
         print(result.message)

--- a/.github/scripts/validate_release_version.py
+++ b/.github/scripts/validate_release_version.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Validate PR release version requirements for main-targeted branches."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import bump_version as version_helper  # isort: skip
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Result for the release version gate."""
+
+    valid: bool
+    message: str
+    pending_auto_bump: bool = False
+    expected_version: str = ""
+
+
+def bump_part_for_branch(head_branch: str) -> Optional[str]:
+    """Return the semantic bump part required for a PR branch."""
+    if head_branch.startswith("bug/"):
+        return "patch"
+    if head_branch.startswith("feature/"):
+        return "minor"
+    return None
+
+
+def parse_version_string(version: str) -> version_helper.Version:
+    """Parse an X.Y.Z version string."""
+    return version_helper.parse_version(f'version = "{version}"\n')
+
+
+def expected_bumped_version(base_version: str, bump_part: str) -> str:
+    """Return the expected version after applying a branch bump part."""
+    return version_helper.format_version(version_helper.bump_version(parse_version_string(base_version), bump_part))
+
+
+def validate_release_version(
+    *,
+    base_version: str,
+    head_version: str,
+    head_branch: str,
+    has_release_code_changes: bool,
+    event_name: str,
+) -> ValidationResult:
+    """Validate the version relationship between the base and PR head."""
+    bump_part = bump_part_for_branch(head_branch)
+    if not bump_part:
+        return ValidationResult(True, f"No release version bump required for branch: {head_branch}")
+
+    if not has_release_code_changes:
+        if head_version != base_version:
+            return ValidationResult(
+                False,
+                (
+                    f"No release code changes detected for {head_branch}, so pyproject.toml must stay at "
+                    f"{base_version}; got {head_version}."
+                ),
+            )
+        return ValidationResult(True, f"No release code changes detected; version remains {head_version}.")
+
+    expected_version = expected_bumped_version(base_version, bump_part)
+    if head_version == expected_version:
+        return ValidationResult(
+            True,
+            f"Version bump is valid: {base_version} -> {head_version} ({bump_part})",
+            expected_version=expected_version,
+        )
+
+    if event_name == "pull_request" and head_version == base_version:
+        return ValidationResult(
+            True,
+            (
+                f"Release code changes detected for {head_branch}; pyproject.toml still matches "
+                f"{base_version} on this pull_request head while auto-version-bump.yml is responsible "
+                f"for updating it to {expected_version}."
+            ),
+            pending_auto_bump=True,
+            expected_version=expected_version,
+        )
+
+    return ValidationResult(
+        False,
+        (
+            f"Expected pyproject.toml version {expected_version} for {head_branch}, got {head_version}. "
+            "Wait for auto-version-bump.yml or re-run it after rebasing on the base branch."
+        ),
+        expected_version=expected_version,
+    )
+
+
+def read_ref_version(ref: str) -> str:
+    """Read pyproject.toml version from a git ref."""
+    return version_helper.format_version(
+        version_helper.parse_version(version_helper.read_file_from_ref(ref, "pyproject.toml"))
+    )
+
+
+def read_worktree_version(path: Path) -> str:
+    """Read pyproject.toml version from the working tree."""
+    return version_helper.format_version(version_helper.parse_version(path.read_text(encoding="utf-8")))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", required=True, help="Git ref containing the target branch pyproject.toml")
+    parser.add_argument("--head-ref", default="HEAD", help="Git ref to compare against --base-ref")
+    parser.add_argument("--head-branch", required=True, help="Pull request source branch name")
+    parser.add_argument(
+        "--event-name",
+        default=os.environ.get("GITHUB_EVENT_NAME", ""),
+        help="GitHub event name, for example pull_request or workflow_dispatch",
+    )
+    parser.add_argument("--file", default="pyproject.toml", help="Path to the working tree pyproject.toml")
+    return parser
+
+
+def main() -> int:
+    """Run the release version gate."""
+    args = build_parser().parse_args()
+    base_version = read_ref_version(args.base_ref)
+    head_version = read_worktree_version(Path(args.file))
+    has_release_changes = version_helper.has_release_code_changes(args.base_ref, args.head_ref)
+
+    result = validate_release_version(
+        base_version=base_version,
+        head_version=head_version,
+        head_branch=args.head_branch,
+        has_release_code_changes=has_release_changes,
+        event_name=args.event_name,
+    )
+    if result.valid:
+        print(result.message)
+        return 0
+
+    print(f"::error::{result.message}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -9,6 +9,21 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number for the final auto-version-bump check.
+        required: true
+      head_branch:
+        description: PR source branch name.
+        required: true
+      base_branch:
+        description: PR target branch name.
+        required: true
+        default: main
+      head_sha:
+        description: Exact PR head SHA to validate without re-bumping.
+        required: true
 
 permissions:
   actions: write
@@ -16,16 +31,37 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: auto-version-bump-${{ github.event.pull_request.number }}
+  group: auto-version-bump-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   auto-version-bump:
     name: auto-version-bump
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          ref: ${{ github.event.inputs.head_sha }}
+          fetch-depth: 1
+
+      - name: Validate dispatched final auto-version context
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          HEAD_SHA: ${{ github.event.inputs.head_sha }}
+        run: |
+          set -euo pipefail
+          actual_head="$(git rev-parse HEAD)"
+          if [ "$actual_head" != "$HEAD_SHA" ]; then
+            echo "::error::Checked out $actual_head, expected final PR head $HEAD_SHA."
+            exit 1
+          fi
+          echo "Auto-version-bump final context validated for $HEAD_SHA."
+
       - name: Resolve bump part from PR branch
+        if: github.event_name == 'pull_request'
         id: bump
         shell: bash
         env:
@@ -46,13 +82,13 @@ jobs:
           esac
 
       - uses: actions/checkout@v4
-        if: steps.bump.outputs.skip != 'true'
+        if: github.event_name == 'pull_request' && steps.bump.outputs.skip != 'true'
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Detect release code changes
-        if: steps.bump.outputs.skip != 'true'
+        if: github.event_name == 'pull_request' && steps.bump.outputs.skip != 'true'
         id: changes
         shell: bash
         run: |
@@ -61,7 +97,7 @@ jobs:
           python3 .github/scripts/bump_version.py --base-ref origin/main --head-ref HEAD --check-release-code-changes
 
       - name: Sync version from latest main
-        if: steps.bump.outputs.skip != 'true'
+        if: github.event_name == 'pull_request' && steps.bump.outputs.skip != 'true'
         id: version
         shell: bash
         env:
@@ -79,7 +115,7 @@ jobs:
 
       - name: Commit version sync
         id: commit
-        if: steps.bump.outputs.skip != 'true'
+        if: github.event_name == 'pull_request' && steps.bump.outputs.skip != 'true'
         shell: bash
         env:
           HEAD_BRANCH: ${{ github.head_ref }}
@@ -102,7 +138,7 @@ jobs:
           echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch PR checks for bumped commit
-        if: steps.commit.outputs.pushed == 'true'
+        if: github.event_name == 'pull_request' && steps.commit.outputs.pushed == 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -120,6 +156,13 @@ jobs:
           done
 
           gh workflow run validate-main-pr-source.yml \
+            --ref "$HEAD_BRANCH" \
+            -f "pr_number=$PR_NUMBER" \
+            -f "head_branch=$HEAD_BRANCH" \
+            -f "base_branch=$BASE_BRANCH" \
+            -f "head_sha=$HEAD_SHA"
+
+          gh workflow run auto-version-bump.yml \
             --ref "$HEAD_BRANCH" \
             -f "pr_number=$PR_NUMBER" \
             -f "head_branch=$HEAD_BRANCH" \

--- a/.github/workflows/validate-main-pr-source.yml
+++ b/.github/workflows/validate-main-pr-source.yml
@@ -97,68 +97,13 @@ jobs:
         env:
           BASE_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.event.inputs.base_branch || 'main' }}
           HEAD_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.event.inputs.head_branch || github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
 
-          case "$HEAD_BRANCH" in
-            bug/*)
-              bump_part="patch"
-              ;;
-            feature/*)
-              bump_part="minor"
-              ;;
-            *)
-              echo "No release version bump required for branch: $HEAD_BRANCH"
-              exit 0
-              ;;
-          esac
-
           base_ref="refs/remotes/origin/${BASE_BRANCH}"
-          has_release_code_changes="$(
-            python3 .github/scripts/bump_version.py --base-ref "$base_ref" --head-ref HEAD --check-release-code-changes
-          )"
-          base_version="$(
-            git show "${base_ref}:pyproject.toml" | python3 -c 'import re,sys; m=re.search(r"(?m)^version\s*=\s*\"(\d+)\.(\d+)\.(\d+)\"", sys.stdin.read()); print(".".join(m.groups()) if m else "");'
-          )"
-          head_version="$(
-            python3 -c 'import re,pathlib; m=re.search(r"(?m)^version\s*=\s*\"(\d+)\.(\d+)\.(\d+)\"", pathlib.Path("pyproject.toml").read_text(encoding="utf-8")); print(".".join(m.groups()) if m else "");'
-          )"
-
-          if [ -z "$base_version" ] || [ -z "$head_version" ]; then
-            echo "::error::Unable to parse pyproject.toml version."
-            exit 1
-          fi
-
-          if [ "$has_release_code_changes" != "true" ]; then
-            if [ "$head_version" != "$base_version" ]; then
-              echo "::error::No release code changes detected for $HEAD_BRANCH, so pyproject.toml must stay at $base_version; got $head_version."
-              exit 1
-            fi
-            echo "No release code changes detected; version remains $head_version."
-            exit 0
-          fi
-
-          expected_version="$(
-            BASE_VERSION="$base_version" BUMP_PART="$bump_part" python3 - <<'PY'
-          import os
-
-          major, minor, patch = (int(part) for part in os.environ["BASE_VERSION"].split("."))
-          part = os.environ["BUMP_PART"]
-          if part == "minor":
-              minor += 1
-              patch = 0
-          elif part == "patch":
-              patch += 1
-          else:
-              raise SystemExit(f"unsupported bump part: {part}")
-          print(f"{major}.{minor}.{patch}")
-          PY
-          )"
-
-          if [ "$head_version" != "$expected_version" ]; then
-            echo "::error::Expected pyproject.toml version $expected_version for $HEAD_BRANCH, got $head_version."
-            echo "::error::Wait for auto-version-bump.yml or re-run it after rebasing on ${BASE_BRANCH}."
-            exit 1
-          fi
-
-          echo "Version bump is valid: $base_version -> $head_version ($bump_part)"
+          python3 .github/scripts/validate_release_version.py \
+            --base-ref "$base_ref" \
+            --head-ref HEAD \
+            --head-branch "$HEAD_BRANCH" \
+            --event-name "$EVENT_NAME"

--- a/.github/workflows/validate-main-pr-source.yml
+++ b/.github/workflows/validate-main-pr-source.yml
@@ -98,6 +98,7 @@ jobs:
           BASE_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.event.inputs.base_branch || 'main' }}
           HEAD_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.event.inputs.head_branch || github.ref_name }}
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action || '' }}
         run: |
           set -euo pipefail
 
@@ -106,4 +107,5 @@ jobs:
             --base-ref "$base_ref" \
             --head-ref HEAD \
             --head-branch "$HEAD_BRANCH" \
-            --event-name "$EVENT_NAME"
+            --event-name "$EVENT_NAME" \
+            --event-action "$EVENT_ACTION"

--- a/tests/whitebox/test_validate_release_version_script.py
+++ b/tests/whitebox/test_validate_release_version_script.py
@@ -1,0 +1,91 @@
+"""Tests for the validate-main PR release version gate."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "validate_release_version.py"
+
+spec = importlib.util.spec_from_file_location("validate_release_version", SCRIPT_PATH)
+validate_release_version = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = validate_release_version
+spec.loader.exec_module(validate_release_version)
+
+
+def test_initial_bug_pr_release_code_commit_can_wait_for_auto_bump() -> None:
+    result = validate_release_version.validate_release_version(
+        base_version="0.2.17",
+        head_version="0.2.17",
+        head_branch="bug/fix-release-code",
+        has_release_code_changes=True,
+        event_name="pull_request",
+    )
+
+    assert result.valid
+    assert result.pending_auto_bump
+
+
+def test_initial_feature_pr_release_code_commit_can_wait_for_auto_bump() -> None:
+    result = validate_release_version.validate_release_version(
+        base_version="0.2.17",
+        head_version="0.2.17",
+        head_branch="feature/new-release-code",
+        has_release_code_changes=True,
+        event_name="pull_request",
+    )
+
+    assert result.valid
+    assert result.pending_auto_bump
+
+
+def test_dispatched_bug_pr_head_requires_auto_bumped_patch_version() -> None:
+    result = validate_release_version.validate_release_version(
+        base_version="0.2.17",
+        head_version="0.2.18",
+        head_branch="bug/fix-release-code",
+        has_release_code_changes=True,
+        event_name="workflow_dispatch",
+    )
+
+    assert result.valid
+    assert not result.pending_auto_bump
+
+
+def test_dispatched_feature_pr_head_requires_auto_bumped_minor_version() -> None:
+    result = validate_release_version.validate_release_version(
+        base_version="0.2.17",
+        head_version="0.3.0",
+        head_branch="feature/new-release-code",
+        has_release_code_changes=True,
+        event_name="workflow_dispatch",
+    )
+
+    assert result.valid
+    assert not result.pending_auto_bump
+
+
+def test_dispatched_release_code_head_without_bump_fails() -> None:
+    result = validate_release_version.validate_release_version(
+        base_version="0.2.17",
+        head_version="0.2.17",
+        head_branch="bug/fix-release-code",
+        has_release_code_changes=True,
+        event_name="workflow_dispatch",
+    )
+
+    assert not result.valid
+    assert "Expected pyproject.toml version 0.2.18" in result.message
+
+
+def test_release_code_head_with_wrong_bump_fails() -> None:
+    result = validate_release_version.validate_release_version(
+        base_version="0.2.17",
+        head_version="0.2.19",
+        head_branch="bug/fix-release-code",
+        has_release_code_changes=True,
+        event_name="workflow_dispatch",
+    )
+
+    assert not result.valid
+    assert "Expected pyproject.toml version 0.2.18" in result.message

--- a/tests/whitebox/test_validate_release_version_script.py
+++ b/tests/whitebox/test_validate_release_version_script.py
@@ -20,6 +20,7 @@ def test_initial_bug_pr_release_code_commit_can_wait_for_auto_bump() -> None:
         head_branch="bug/fix-release-code",
         has_release_code_changes=True,
         event_name="pull_request",
+        event_action="opened",
     )
 
     assert result.valid
@@ -33,10 +34,55 @@ def test_initial_feature_pr_release_code_commit_can_wait_for_auto_bump() -> None
         head_branch="feature/new-release-code",
         has_release_code_changes=True,
         event_name="pull_request",
+        event_action="synchronize",
     )
 
     assert result.valid
     assert result.pending_auto_bump
+
+
+def test_no_release_code_pr_without_version_change_passes() -> None:
+    result = validate_release_version.validate_release_version(
+        base_version="0.2.17",
+        head_version="0.2.17",
+        head_branch="bug/docs-only",
+        has_release_code_changes=False,
+        event_name="pull_request",
+        event_action="opened",
+    )
+
+    assert result.valid
+    assert not result.pending_auto_bump
+    assert "No release code changes detected" in result.message
+
+
+def test_no_release_code_pr_with_version_change_fails() -> None:
+    result = validate_release_version.validate_release_version(
+        base_version="0.2.17",
+        head_version="0.2.18",
+        head_branch="bug/docs-only",
+        has_release_code_changes=False,
+        event_name="pull_request",
+        event_action="opened",
+    )
+
+    assert not result.valid
+    assert "must stay at 0.2.17" in result.message
+
+
+def test_edited_bug_pr_release_code_commit_cannot_wait_for_auto_bump() -> None:
+    result = validate_release_version.validate_release_version(
+        base_version="0.2.17",
+        head_version="0.2.17",
+        head_branch="bug/fix-release-code",
+        has_release_code_changes=True,
+        event_name="pull_request",
+        event_action="edited",
+    )
+
+    assert not result.valid
+    assert not result.pending_auto_bump
+    assert "Expected pyproject.toml version 0.2.18" in result.message
 
 
 def test_dispatched_bug_pr_head_requires_auto_bumped_patch_version() -> None:
@@ -46,6 +92,7 @@ def test_dispatched_bug_pr_head_requires_auto_bumped_patch_version() -> None:
         head_branch="bug/fix-release-code",
         has_release_code_changes=True,
         event_name="workflow_dispatch",
+        event_action="",
     )
 
     assert result.valid
@@ -59,6 +106,7 @@ def test_dispatched_feature_pr_head_requires_auto_bumped_minor_version() -> None
         head_branch="feature/new-release-code",
         has_release_code_changes=True,
         event_name="workflow_dispatch",
+        event_action="",
     )
 
     assert result.valid
@@ -72,6 +120,7 @@ def test_dispatched_release_code_head_without_bump_fails() -> None:
         head_branch="bug/fix-release-code",
         has_release_code_changes=True,
         event_name="workflow_dispatch",
+        event_action="",
     )
 
     assert not result.valid
@@ -85,6 +134,7 @@ def test_release_code_head_with_wrong_bump_fails() -> None:
         head_branch="bug/fix-release-code",
         has_release_code_changes=True,
         event_name="workflow_dispatch",
+        event_action="",
     )
 
     assert not result.valid

--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -14,12 +14,18 @@ def test_auto_version_bump_dispatches_required_checks_after_bot_push() -> None:
     workflow = (ROOT / ".github/workflows/auto-version-bump.yml").read_text(encoding="utf-8")
 
     assert "actions: write" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "head_branch:" in workflow
+    assert "base_branch:" in workflow
+    assert "head_sha:" in workflow
     assert "id: commit" in workflow
     assert "pushed=true" in workflow
+    assert "Validate dispatched final auto-version context" in workflow
     assert "Dispatch PR checks for bumped commit" in workflow
     assert "steps.commit.outputs.pushed == 'true'" in workflow
     assert 'gh workflow run "$workflow" --ref "$HEAD_BRANCH"' in workflow
     assert "python-app.yml pylint.yml mypy.yml" in workflow
+    assert "gh workflow run auto-version-bump.yml" in workflow
     assert "gh workflow run auto-merge-pr.yml" in workflow
     assert "gh workflow run validate-main-pr-source.yml" in workflow
     assert '-f "head_sha=$HEAD_SHA"' in workflow
@@ -41,9 +47,11 @@ def test_validate_main_source_branch_uses_tested_release_version_gate() -> None:
     workflow = (ROOT / ".github/workflows/validate-main-pr-source.yml").read_text(encoding="utf-8")
 
     assert "EVENT_NAME: ${{ github.event_name }}" in workflow
+    assert "EVENT_ACTION: ${{ github.event.action || '' }}" in workflow
     assert "python3 .github/scripts/validate_release_version.py" in workflow
     assert '--head-branch "$HEAD_BRANCH"' in workflow
     assert '--event-name "$EVENT_NAME"' in workflow
+    assert '--event-action "$EVENT_ACTION"' in workflow
 
 
 def test_auto_merge_pr_workflow_enables_merge_after_required_checks() -> None:

--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -37,6 +37,15 @@ def test_validate_main_source_branch_supports_dispatched_head_validation() -> No
     assert "github.event.inputs.head_sha" in workflow
 
 
+def test_validate_main_source_branch_uses_tested_release_version_gate() -> None:
+    workflow = (ROOT / ".github/workflows/validate-main-pr-source.yml").read_text(encoding="utf-8")
+
+    assert "EVENT_NAME: ${{ github.event_name }}" in workflow
+    assert "python3 .github/scripts/validate_release_version.py" in workflow
+    assert '--head-branch "$HEAD_BRANCH"' in workflow
+    assert '--event-name "$EVENT_NAME"' in workflow
+
+
 def test_auto_merge_pr_workflow_enables_merge_after_required_checks() -> None:
     workflow = (ROOT / ".github/workflows/auto-merge-pr.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary:
- Extract the Validate Main PR Source release-version gate into a tested helper script.
- Allow initial bug/* and feature/* pull_request heads with release-code changes to pass while auto-version-bump.yml owns the version commit.
- Keep workflow_dispatch validation strict so the final bumped PR head must have the expected patch or minor version.

Verification:
- make format
- python3 -m pytest -o addopts= tests/whitebox/test_bump_version_script.py tests/whitebox/test_validate_release_version_script.py tests/whitebox/test_workflow_automation.py
- make test
- make lint
- python3 .github/scripts/validate_release_version.py --base-ref refs/remotes/origin/main --head-ref HEAD --head-branch bug/validate-main-pr-source-first-commit --event-name pull_request