### PR TITLE
TASK-ci: verify first commit validate pass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi-project-manager"
-version = "0.2.17"
+version = "0.2.18"
 authors = [
   { name="wangguanran", email="elvans.wang@gmail.com" },
 ]

--- a/scripts/write_build_info.py
+++ b/scripts/write_build_info.py
@@ -4,6 +4,7 @@ Generate src/_build_info.py with the current git commit hash.
 
 This is intended for build pipelines (PyInstaller / wheel) so `--version` can
 still show a commit hash even when `.git` is not shipped with the artifact.
+The generated module stays limited to build metadata constants.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Summary:
- Temporary validation PR for the first release-code commit gate.
- Changes a build metadata helper docstring only.

Verification:
- make format
- python3 .github/scripts/bump_version.py --base-ref origin/main --head-ref HEAD --check-release-code-changes

Cleanup:
- Close without merging after the first commit check result is observed.