### PR TITLE
TASK-release: trigger publish after main merge

### DIFF
--- a/.github/workflows/release-after-main-merge.yml
+++ b/.github/workflows/release-after-main-merge.yml
@@ -55,25 +55,33 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=tag-exists" >> "$GITHUB_OUTPUT"
-            echo "Release tag ${TAG} already exists; stable release dispatch is a no-op."
-            exit 0
-          fi
-
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "skip_reason=release-exists" >> "$GITHUB_OUTPUT"
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
             echo "GitHub Release ${TAG} already exists; stable release dispatch is a no-op."
+            exit 0
+          fi
+
+          if remote_tag_ref="$(git ls-remote --exit-code --tags origin "refs/tags/${TAG}" 2>/dev/null)"; then
+            remote_tag_sha="$(printf '%s\n' "$remote_tag_ref" | sed -n '1s/[[:space:]].*//p')"
+            if [ "$remote_tag_sha" != "$GITHUB_SHA" ]; then
+              echo "::error::Release tag ${TAG} points to ${remote_tag_sha}, expected ${GITHUB_SHA}; refusing to dispatch publish-release.yml."
+              exit 1
+            fi
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=tag-exists-release-missing" >> "$GITHUB_OUTPUT"
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release tag ${TAG} points to ${GITHUB_SHA}, but GitHub Release is missing; dispatching publish-release.yml."
             exit 0
           fi
 
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "skip_reason=" >> "$GITHUB_OUTPUT"
+          echo "tag_exists=false" >> "$GITHUB_OUTPUT"
 
       - name: Create matching stable release tag
-        if: steps.existing.outputs.skip != 'true'
+        if: steps.existing.outputs.skip != 'true' && steps.existing.outputs.tag_exists != 'true'
         shell: bash
         env:
           TAG: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/release-after-main-merge.yml
+++ b/.github/workflows/release-after-main-merge.yml
@@ -1,0 +1,103 @@
+name: Release After Main Merge
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: release-after-main-merge-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag-and-dispatch-release:
+    name: tag-and-dispatch-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve release tag from pyproject.toml
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version_and_tag="$(
+            python3 - <<'PY'
+          import re
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          version = data["project"]["version"]
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version):
+              print("::error::Expected pyproject.toml project.version to be X.Y.Z", file=sys.stderr)
+              raise SystemExit(1)
+          tag = f"v{version}"
+          print(version)
+          print(tag)
+          PY
+          )"
+          version="$(printf '%s\n' "$version_and_tag" | sed -n '1p')"
+          tag="$(printf '%s\n' "$version_and_tag" | sed -n '2p')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Check existing release tag or GitHub Release
+        id: existing
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=tag-exists" >> "$GITHUB_OUTPUT"
+            echo "Release tag ${TAG} already exists; stable release dispatch is a no-op."
+            exit 0
+          fi
+
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=release-exists" >> "$GITHUB_OUTPUT"
+            echo "GitHub Release ${TAG} already exists; stable release dispatch is a no-op."
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=" >> "$GITHUB_OUTPUT"
+
+      - name: Create matching stable release tag
+        if: steps.existing.outputs.skip != 'true'
+        shell: bash
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG" "$GITHUB_SHA"
+          git push origin "refs/tags/${TAG}"
+
+      - name: Dispatch tag-based release workflow
+        if: steps.existing.outputs.skip != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if gh workflow run publish-release.yml --ref "$TAG"; then
+              echo "Dispatched publish-release.yml for ${TAG}."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Failed to dispatch publish-release.yml for ${TAG}."
+          exit 1

--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -79,3 +79,44 @@ def test_required_pr_ci_workflows_run_for_all_main_pull_requests() -> None:
 
         assert 'branches: [ "main" ]' in pull_request_block or 'branches: ["main"]' in pull_request_block
         assert "paths:" not in pull_request_block
+
+
+def test_release_after_main_merge_runs_on_main_push_and_tags_pyproject_version() -> None:
+    workflow_path = ROOT / ".github/workflows/release-after-main-merge.yml"
+    assert workflow_path.exists()
+
+    workflow = workflow_path.read_text(encoding="utf-8")
+
+    assert "push:" in workflow
+    assert "- main" in workflow
+    assert "contents: write" in workflow
+    assert "actions: write" in workflow
+    assert "tomllib" in workflow
+    assert "pyproject.toml" in workflow
+    assert 'tag = f"v{version}"' in workflow
+    assert "Expected pyproject.toml project.version to be X.Y.Z" in workflow
+    assert 'echo "tag=${tag}" >> "$GITHUB_OUTPUT"' in workflow
+
+
+def test_release_after_main_merge_skips_existing_tag_or_release_without_failure() -> None:
+    workflow = (ROOT / ".github/workflows/release-after-main-merge.yml").read_text(encoding="utf-8")
+
+    assert 'git ls-remote --exit-code --tags origin "refs/tags/${TAG}"' in workflow
+    assert 'gh release view "$TAG"' in workflow
+    assert "skip_reason=tag-exists" in workflow
+    assert "skip_reason=release-exists" in workflow
+    assert "steps.existing.outputs.skip != 'true'" in workflow
+
+
+def test_release_after_main_merge_reuses_publish_release_validation() -> None:
+    workflow = (ROOT / ".github/workflows/release-after-main-merge.yml").read_text(encoding="utf-8")
+    publish_release = (ROOT / ".github/workflows/publish-release.yml").read_text(encoding="utf-8")
+
+    assert 'git tag "$TAG" "$GITHUB_SHA"' in workflow
+    assert 'git push origin "refs/tags/${TAG}"' in workflow
+    assert 'gh workflow run publish-release.yml --ref "$TAG"' in workflow
+    assert "twine upload" not in workflow
+    assert "docker/build-push-action" not in workflow
+    assert "  push:\n    tags:" in publish_release
+    assert "  workflow_dispatch:" in publish_release
+    assert "Validate pyproject version matches release tag" in publish_release

--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -98,14 +98,24 @@ def test_release_after_main_merge_runs_on_main_push_and_tags_pyproject_version()
     assert 'echo "tag=${tag}" >> "$GITHUB_OUTPUT"' in workflow
 
 
-def test_release_after_main_merge_skips_existing_tag_or_release_without_failure() -> None:
+def test_release_after_main_merge_skips_existing_release_without_failure() -> None:
     workflow = (ROOT / ".github/workflows/release-after-main-merge.yml").read_text(encoding="utf-8")
 
     assert 'git ls-remote --exit-code --tags origin "refs/tags/${TAG}"' in workflow
     assert 'gh release view "$TAG"' in workflow
-    assert "skip_reason=tag-exists" in workflow
     assert "skip_reason=release-exists" in workflow
     assert "steps.existing.outputs.skip != 'true'" in workflow
+
+
+def test_release_after_main_merge_recovers_existing_tag_without_release() -> None:
+    workflow = (ROOT / ".github/workflows/release-after-main-merge.yml").read_text(encoding="utf-8")
+
+    assert "tag_exists=true" in workflow
+    assert "skip_reason=tag-exists-release-missing" in workflow
+    assert 'if [ "$remote_tag_sha" != "$GITHUB_SHA" ]; then' in workflow
+    assert "refusing to dispatch publish-release.yml" in workflow
+    assert "steps.existing.outputs.tag_exists != 'true'" in workflow
+    assert "dispatching publish-release.yml." in workflow
 
 
 def test_release_after_main_merge_reuses_publish_release_validation() -> None:


### PR DESCRIPTION
## Summary
- Add a main-push release handoff workflow that reads `pyproject.toml`, computes the matching stable tag `vX.Y.Z`, and creates that tag on the merged main commit.
- Skip safely when the matching tag already exists or the GitHub Release already exists, so duplicate main pushes are no-op.
- Reuse the existing `publish-release.yml` by dispatching it on the created tag instead of duplicating PyPI, GitHub Release, or Docker publish logic.

## Current gap
- Stable publishing currently runs only from `v*` tag pushes or manual `workflow_dispatch`.
- Merging a PR to `main` updates `pyproject.toml` when needed, but does not create the matching release tag or start the stable publish workflow.

## Verification
- `make format`
- `python -m pytest -o addopts="" tests/whitebox/test_workflow_automation.py tests/whitebox/test_bump_version_script.py tests/whitebox/test_validate_release_version_script.py`
- `python -m pytest`
- `git diff --check`

## Safety notes
- No new external secrets are required; the workflow uses the default GitHub Actions token permissions for tag creation and workflow dispatch.
- The existing `publish-release.yml` tag/version validation remains the release gate.
- This PR is draft intentionally so review and merge can be handled separately without auto-merge.