### PR TITLE
TASK-release: dispatch publish after auto-merge

### DIFF
--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -57,6 +57,11 @@ jobs:
             echo "PR #$PR_NUMBER targets $base_branch, not main; no stable release watcher needed."
             exit 0
           fi
+          current_head="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid)"
+          if [ "$current_head" != "$HEAD_SHA" ]; then
+            echo "PR #$PR_NUMBER head moved from $HEAD_SHA to $current_head; skipping stale release watcher dispatch."
+            exit 0
+          fi
 
           # GITHUB_TOKEN-created auto-merge pushes do not trigger push workflows.
           # workflow_dispatch is exempt, so this watcher waits for the merge SHA.

--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   enable-auto-merge:
@@ -42,3 +43,26 @@ jobs:
             exit 0
           fi
           gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --merge --delete-branch --match-head-commit "$HEAD_SHA"
+
+      - name: Dispatch release watcher for GitHub-token auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.inputs.head_sha || github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          base_branch="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json baseRefName --jq .baseRefName)"
+          if [ "$base_branch" != "main" ]; then
+            echo "PR #$PR_NUMBER targets $base_branch, not main; no stable release watcher needed."
+            exit 0
+          fi
+
+          # GITHUB_TOKEN-created auto-merge pushes do not trigger push workflows.
+          # workflow_dispatch is exempt, so this watcher waits for the merge SHA.
+          gh workflow run release-after-main-merge.yml \
+            --repo "$REPO" \
+            --ref "$base_branch" \
+            -f "target_ref=$base_branch" \
+            -f "pr_number=$PR_NUMBER" \
+            -f "pr_head_sha=$HEAD_SHA"

--- a/.github/workflows/release-after-main-merge.yml
+++ b/.github/workflows/release-after-main-merge.yml
@@ -26,7 +26,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: release-after-main-merge-${{ github.event.inputs.target_sha || github.event.inputs.pr_number || github.sha }}
+  group: release-after-main-merge-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target_sha != '' && github.event.inputs.target_sha || github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '' && format('pr-{0}-{1}', github.event.inputs.pr_number, github.event.inputs.pr_head_sha) || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '' && github.event.inputs.target_sha == '' }}
 
 jobs:
@@ -83,10 +83,8 @@ jobs:
             done
 
             if [ -z "$target_sha" ]; then
-              echo "::notice::PR #${INPUT_PR_NUMBER} was not merged before the release watcher timeout; no release was dispatched."
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              echo "skip_reason=pr-not-merged" >> "$GITHUB_OUTPUT"
-              exit 0
+              echo "::error::PR #${INPUT_PR_NUMBER} was not merged before the release watcher timeout; release dispatch cannot be verified."
+              exit 1
             fi
           else
             echo "::error::workflow_dispatch requires target_sha or pr_number."

--- a/.github/workflows/release-after-main-merge.yml
+++ b/.github/workflows/release-after-main-merge.yml
@@ -4,23 +4,132 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Exact main commit SHA to tag and release.
+        required: false
+      target_ref:
+        description: Main branch ref containing the target commit.
+        required: false
+        default: main
+      pr_number:
+        description: Pull request number to watch until GitHub auto-merge creates the merge commit.
+        required: false
+      pr_head_sha:
+        description: Exact PR head SHA expected before waiting for its merge commit.
+        required: false
 
 permissions:
   contents: write
   actions: write
+  pull-requests: read
 
 concurrency:
-  group: release-after-main-merge-${{ github.ref }}
-  cancel-in-progress: false
+  group: release-after-main-merge-${{ github.event.inputs.target_sha || github.event.inputs.pr_number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '' && github.event.inputs.target_sha == '' }}
 
 jobs:
   tag-and-dispatch-release:
     name: tag-and-dispatch-release
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve target main commit
+        id: target
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TARGET_SHA: ${{ github.event.inputs.target_sha || '' }}
+          INPUT_TARGET_REF: ${{ github.event.inputs.target_ref || 'main' }}
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number || '' }}
+          INPUT_PR_HEAD_SHA: ${{ github.event.inputs.pr_head_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          target_ref="${INPUT_TARGET_REF:-main}"
+          target_sha=""
+
+          if [ "$EVENT_NAME" = "push" ]; then
+            target_ref="${GITHUB_REF_NAME:-main}"
+            target_sha="$GITHUB_SHA"
+          elif [ -n "$INPUT_TARGET_SHA" ]; then
+            target_sha="$INPUT_TARGET_SHA"
+          elif [ -n "$INPUT_PR_NUMBER" ]; then
+            if [ -z "$INPUT_PR_HEAD_SHA" ]; then
+              echo "::error::pr_head_sha is required when pr_number is provided."
+              exit 1
+            fi
+
+            for attempt in $(seq 1 60); do
+              pr_meta="$(
+                gh pr view "$INPUT_PR_NUMBER" \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --json headRefOid,mergedAt,mergeCommit \
+                  --jq '[.headRefOid, (.mergedAt // ""), (.mergeCommit.oid // "")] | @tsv'
+              )"
+              IFS=$'\t' read -r current_head merged_at merge_sha <<< "$pr_meta"
+              if [ "$current_head" != "$INPUT_PR_HEAD_SHA" ]; then
+                echo "::notice::PR #${INPUT_PR_NUMBER} head moved from ${INPUT_PR_HEAD_SHA} to ${current_head}; stale release watcher exits."
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+                echo "skip_reason=stale-pr-head" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              if [ -n "$merged_at" ] && [ -n "$merge_sha" ]; then
+                target_sha=$merge_sha
+                break
+              fi
+              sleep 30
+            done
+
+            if [ -z "$target_sha" ]; then
+              echo "::notice::PR #${INPUT_PR_NUMBER} was not merged before the release watcher timeout; no release was dispatched."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "skip_reason=pr-not-merged" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            echo "::error::workflow_dispatch requires target_sha or pr_number."
+            exit 1
+          fi
+
+          if ! [[ "$target_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Target SHA must be a full 40-character lowercase hex commit, got '${target_sha}'."
+            exit 1
+          fi
+
+          echo "sha=${target_sha}" >> "$GITHUB_OUTPUT"
+          echo "ref=${target_ref}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
+        if: steps.target.outputs.skip != 'true'
+        with:
+          ref: ${{ steps.target.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Validate target commit is on main
+        if: steps.target.outputs.skip != 'true'
+        shell: bash
+        env:
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+          TARGET_REF: ${{ steps.target.outputs.ref }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          if [ "$actual_sha" != "$TARGET_SHA" ]; then
+            echo "::error::Checked out ${actual_sha}, expected target main SHA ${TARGET_SHA}."
+            exit 1
+          fi
+
+          git fetch --no-tags --prune origin "+refs/heads/${TARGET_REF}:refs/remotes/origin/${TARGET_REF}"
+          if ! git merge-base --is-ancestor "$TARGET_SHA" "refs/remotes/origin/${TARGET_REF}"; then
+            echo "::error::Target SHA ${TARGET_SHA} is not reachable from origin/${TARGET_REF}; refusing to release."
+            exit 1
+          fi
 
       - name: Resolve release tag from pyproject.toml
+        if: steps.target.outputs.skip != 'true'
         id: version
         shell: bash
         run: |
@@ -48,11 +157,13 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
       - name: Check existing release tag or GitHub Release
+        if: steps.target.outputs.skip != 'true'
         id: existing
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
         run: |
           set -euo pipefail
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
@@ -65,14 +176,14 @@ jobs:
 
           if remote_tag_ref="$(git ls-remote --exit-code --tags origin "refs/tags/${TAG}" 2>/dev/null)"; then
             remote_tag_sha="$(printf '%s\n' "$remote_tag_ref" | sed -n '1s/[[:space:]].*//p')"
-            if [ "$remote_tag_sha" != "$GITHUB_SHA" ]; then
-              echo "::error::Release tag ${TAG} points to ${remote_tag_sha}, expected ${GITHUB_SHA}; refusing to dispatch publish-release.yml."
+            if [ "$remote_tag_sha" != "$TARGET_SHA" ]; then
+              echo "::error::Release tag ${TAG} points to ${remote_tag_sha}, expected ${TARGET_SHA}; refusing to dispatch publish-release.yml."
               exit 1
             fi
             echo "skip=false" >> "$GITHUB_OUTPUT"
             echo "skip_reason=tag-exists-release-missing" >> "$GITHUB_OUTPUT"
             echo "tag_exists=true" >> "$GITHUB_OUTPUT"
-            echo "Release tag ${TAG} points to ${GITHUB_SHA}, but GitHub Release is missing; dispatching publish-release.yml."
+            echo "Release tag ${TAG} points to ${TARGET_SHA}, but GitHub Release is missing; dispatching publish-release.yml."
             exit 0
           fi
 
@@ -81,19 +192,20 @@ jobs:
           echo "tag_exists=false" >> "$GITHUB_OUTPUT"
 
       - name: Create matching stable release tag
-        if: steps.existing.outputs.skip != 'true' && steps.existing.outputs.tag_exists != 'true'
+        if: steps.target.outputs.skip != 'true' && steps.existing.outputs.skip != 'true' && steps.existing.outputs.tag_exists != 'true'
         shell: bash
         env:
           TAG: ${{ steps.version.outputs.tag }}
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "$TAG" "$GITHUB_SHA"
+          git tag "$TAG" "$TARGET_SHA"
           git push origin "refs/tags/${TAG}"
 
       - name: Dispatch tag-based release workflow
-        if: steps.existing.outputs.skip != 'true'
+        if: steps.target.outputs.skip != 'true' && steps.existing.outputs.skip != 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -87,6 +87,19 @@ def test_auto_merge_pr_workflow_dispatches_release_watcher_for_github_token_merg
     assert '-f "pr_head_sha=$HEAD_SHA"' in workflow
 
 
+def test_auto_merge_pr_workflow_rechecks_head_before_release_watcher_dispatch() -> None:
+    workflow = (ROOT / ".github/workflows/auto-merge-pr.yml").read_text(encoding="utf-8")
+
+    assert (
+        workflow.count('current_head="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid)"')
+        == 2
+    )
+    assert (
+        'echo "PR #$PR_NUMBER head moved from $HEAD_SHA to $current_head; skipping stale release watcher dispatch."'
+        in workflow
+    )
+
+
 def test_required_pr_ci_workflows_run_for_all_main_pull_requests() -> None:
     for workflow_name in ("python-app.yml", "pylint.yml", "mypy.yml"):
         workflow = (ROOT / f".github/workflows/{workflow_name}").read_text(encoding="utf-8")
@@ -131,6 +144,28 @@ def test_release_after_main_merge_supports_dispatch_target_sha_and_pr_merge_wait
     assert "Validate target commit is on main" in workflow
     assert "ref: ${{ steps.target.outputs.sha }}" in workflow
     assert "steps.target.outputs.skip != 'true' && steps.existing.outputs.skip != 'true'" in workflow
+
+
+def test_release_after_main_merge_pr_watcher_concurrency_includes_expected_head() -> None:
+    workflow = (ROOT / ".github/workflows/release-after-main-merge.yml").read_text(encoding="utf-8")
+
+    assert (
+        "group: release-after-main-merge-${{ github.event_name == 'workflow_dispatch' && "
+        "github.event.inputs.target_sha != '' && github.event.inputs.target_sha || "
+        "github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '' && "
+        "format('pr-{0}-{1}', github.event.inputs.pr_number, github.event.inputs.pr_head_sha) || github.sha }}"
+        in workflow
+    )
+
+
+def test_release_after_main_merge_pr_watcher_timeout_fails_visibly() -> None:
+    workflow = (ROOT / ".github/workflows/release-after-main-merge.yml").read_text(encoding="utf-8")
+
+    assert (
+        'echo "::error::PR #${INPUT_PR_NUMBER} was not merged before the release watcher timeout; '
+        'release dispatch cannot be verified."' in workflow
+    )
+    assert "skip_reason=pr-not-merged" not in workflow
 
 
 def test_release_after_main_merge_skips_existing_release_without_failure() -> None:

--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -63,6 +63,7 @@ def test_auto_merge_pr_workflow_enables_merge_after_required_checks() -> None:
     assert "head_sha:" in workflow
     assert "pull-requests: write" in workflow
     assert "contents: write" in workflow
+    assert "actions: write" in workflow
     assert "github.event.pull_request.draft == false" in workflow
     assert "REPO: ${{ github.repository }}" in workflow
     assert 'gh pr view "$PR_NUMBER" --repo "$REPO"' in workflow
@@ -70,6 +71,20 @@ def test_auto_merge_pr_workflow_enables_merge_after_required_checks() -> None:
         'gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --merge --delete-branch --match-head-commit "$HEAD_SHA"'
         in workflow
     )
+
+
+def test_auto_merge_pr_workflow_dispatches_release_watcher_for_github_token_merges() -> None:
+    workflow = (ROOT / ".github/workflows/auto-merge-pr.yml").read_text(encoding="utf-8")
+
+    assert "Dispatch release watcher for GitHub-token auto-merge" in workflow
+    assert "GITHUB_TOKEN-created auto-merge pushes do not trigger push workflows" in workflow
+    assert "workflow_dispatch is exempt" in workflow
+    assert 'base_branch="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json baseRefName --jq .baseRefName)"' in workflow
+    assert "gh workflow run release-after-main-merge.yml" in workflow
+    assert '--repo "$REPO"' in workflow
+    assert '-f "target_ref=$base_branch"' in workflow
+    assert '-f "pr_number=$PR_NUMBER"' in workflow
+    assert '-f "pr_head_sha=$HEAD_SHA"' in workflow
 
 
 def test_required_pr_ci_workflows_run_for_all_main_pull_requests() -> None:
@@ -98,6 +113,26 @@ def test_release_after_main_merge_runs_on_main_push_and_tags_pyproject_version()
     assert 'echo "tag=${tag}" >> "$GITHUB_OUTPUT"' in workflow
 
 
+def test_release_after_main_merge_supports_dispatch_target_sha_and_pr_merge_wait() -> None:
+    workflow = (ROOT / ".github/workflows/release-after-main-merge.yml").read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "target_sha:" in workflow
+    assert "target_ref:" in workflow
+    assert "pr_number:" in workflow
+    assert "pr_head_sha:" in workflow
+    assert "Resolve target main commit" in workflow
+    assert "INPUT_TARGET_SHA" in workflow
+    assert "INPUT_PR_NUMBER" in workflow
+    assert "mergedAt" in workflow
+    assert "mergeCommit" in workflow
+    assert "target_sha=$merge_sha" in workflow
+    assert 'echo "sha=${target_sha}" >> "$GITHUB_OUTPUT"' in workflow
+    assert "Validate target commit is on main" in workflow
+    assert "ref: ${{ steps.target.outputs.sha }}" in workflow
+    assert "steps.target.outputs.skip != 'true' && steps.existing.outputs.skip != 'true'" in workflow
+
+
 def test_release_after_main_merge_skips_existing_release_without_failure() -> None:
     workflow = (ROOT / ".github/workflows/release-after-main-merge.yml").read_text(encoding="utf-8")
 
@@ -112,7 +147,7 @@ def test_release_after_main_merge_recovers_existing_tag_without_release() -> Non
 
     assert "tag_exists=true" in workflow
     assert "skip_reason=tag-exists-release-missing" in workflow
-    assert 'if [ "$remote_tag_sha" != "$GITHUB_SHA" ]; then' in workflow
+    assert 'if [ "$remote_tag_sha" != "$TARGET_SHA" ]; then' in workflow
     assert "refusing to dispatch publish-release.yml" in workflow
     assert "steps.existing.outputs.tag_exists != 'true'" in workflow
     assert "dispatching publish-release.yml." in workflow
@@ -122,7 +157,7 @@ def test_release_after_main_merge_reuses_publish_release_validation() -> None:
     workflow = (ROOT / ".github/workflows/release-after-main-merge.yml").read_text(encoding="utf-8")
     publish_release = (ROOT / ".github/workflows/publish-release.yml").read_text(encoding="utf-8")
 
-    assert 'git tag "$TAG" "$GITHUB_SHA"' in workflow
+    assert 'git tag "$TAG" "$TARGET_SHA"' in workflow
     assert 'git push origin "refs/tags/${TAG}"' in workflow
     assert 'gh workflow run publish-release.yml --ref "$TAG"' in workflow
     assert "twine upload" not in workflow


### PR DESCRIPTION
## Summary
- Add a `workflow_dispatch` path to `Release After Main Merge` so it can release an explicit main commit SHA instead of relying only on `push`.
- Have `Auto Merge PR` dispatch a release watcher for main-targeting PRs after enabling GitHub auto-merge.
- Preserve the existing release tri-state: release exists no-op; tag exists and release missing validates the tag target before dispatch; tag missing creates the tag and dispatches `publish-release.yml`.

## Root cause evidence
- PR #201 was merged by `github-actions[bot]` at merge commit `49b3c728f2675b18e7292e85952fd5ba44a6311a`.
- The merge commit had only dynamic Actions runs; `Release After Main Merge` had zero runs while the workflow was active.
- GitHub documents that events created with the repository token do not create normal workflow runs, with `workflow_dispatch` as an exception.

## Verification
- RED: new workflow automation tests failed before the workflow changes.
- GREEN: `make format`.
- GREEN: `python3 -m pytest -o addopts='' tests/whitebox/test_bump_version_script.py tests/whitebox/test_validate_release_version_script.py tests/whitebox/test_workflow_automation.py`.
- GREEN: `make test`.
- GREEN: `make lint`.
- GREEN: YAML parse check for the touched release workflows.

## Release safety
- Did not create `v0.2.17`.
- Did not create a release.
- Did not manually dispatch publish workflows.