### PR TITLE
TASK-release: verify main merge release trigger

### DIFF
--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -82,6 +82,7 @@ def test_auto_merge_pr_workflow_dispatches_release_watcher_for_github_token_merg
     assert 'base_branch="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json baseRefName --jq .baseRefName)"' in workflow
     assert "gh workflow run release-after-main-merge.yml" in workflow
     assert '--repo "$REPO"' in workflow
+    assert '--ref "$base_branch"' in workflow
     assert '-f "target_ref=$base_branch"' in workflow
     assert '-f "pr_number=$PR_NUMBER"' in workflow
     assert '-f "pr_head_sha=$HEAD_SHA"' in workflow


### PR DESCRIPTION
Validation PR for the post-#202 auto-release path. Change is test-only: assert auto-merge dispatches release-after-main-merge on the base branch. No release-code or version change.