### PR TITLE
TASK-release: expose projman in publish tests

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,6 +29,14 @@ jobs:
         shell: bash
         run: bash build.sh
 
+      - name: Install package entry point
+        shell: bash
+        run: |
+          source venv/bin/activate
+          python -m pip install --no-deps --no-build-isolation -e .
+          command -v projman
+          projman --version
+
       - name: Run tests
         shell: bash
         run: bash -lc "source venv/bin/activate && pytest"

--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -201,3 +201,16 @@ def test_release_after_main_merge_reuses_publish_release_validation() -> None:
     assert "  push:\n    tags:" in publish_release
     assert "  workflow_dispatch:" in publish_release
     assert "Validate pyproject version matches release tag" in publish_release
+
+
+def test_publish_release_test_job_installs_console_script_before_pytest() -> None:
+    workflow = (ROOT / ".github/workflows/publish-release.yml").read_text(encoding="utf-8")
+
+    build_index = workflow.index("- name: Build project")
+    install_index = workflow.index("- name: Install package entry point")
+    test_index = workflow.index("- name: Run tests")
+
+    assert build_index < install_index < test_index
+    assert "source venv/bin/activate" in workflow
+    assert "python -m pip install --no-deps --no-build-isolation -e ." in workflow
+    assert "command -v projman" in workflow


### PR DESCRIPTION
## Summary

Fix the `publish-release.yml` test job so the installed `projman` console script exists before pytest runs. The failing `v0.2.17` publish run built the package and binary, then activated the build venv and ran pytest without installing the current package entry point into that venv, so `tests/blackbox/test_projman_console_script.py` could not resolve `projman`.

## Changes

- Add an `Install package entry point` step after the publish workflow build step.
- Install the current package editable into the workflow venv with `python -m pip install --no-deps --no-build-isolation -e .`.
- Check `command -v projman` and `projman --version` before running pytest.
- Add a whitebox workflow automation test that requires this install/exposure step before `Run tests`.

## Verification

- RED: the new workflow automation test failed before the workflow change because the install step was missing.
- GREEN: `python -m pytest -o addopts='' tests/whitebox/test_workflow_automation.py`
- GREEN: console script blackbox test passed from an editable install with a narrowed outer PATH.
- GREEN: full suite passed with `python -m pytest -o addopts=''`.
- GREEN: `make format` and `make lint` completed; lint printed a non-fatal cache warning from the sandboxed local environment.

## Release note

Do not rerun the existing publish-release workflow from this PR. After this fix is merged, a follow-up release task can decide how to rerun `publish-release.yml` for the existing `v0.2.17` tag.