### PR TITLE
Skip draft PR auto-merge attempts

### DIFF
--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enable merge after required checks
+        id: enable
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
@@ -42,9 +43,16 @@ jobs:
             echo "PR #$PR_NUMBER head moved from $HEAD_SHA to $current_head; skipping stale auto-merge request."
             exit 0
           fi
-          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --merge --delete-branch --match-head-commit "$HEAD_SHA"
+          is_draft="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft --jq .isDraft)"
+          if [ "$is_draft" = "true" ]; then
+            echo "skipped_draft=true" >> "$GITHUB_OUTPUT"
+            echo "PR #$PR_NUMBER is draft/WIP; waiting for gh pr ready before enabling auto-merge."
+            exit 0
+          fi
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash --delete-branch --match-head-commit "$HEAD_SHA"
 
       - name: Dispatch release watcher for GitHub-token auto-merge
+        if: steps.enable.outputs.skipped_draft != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,14 @@ You are working in the `ProjectManager` repository - a Python CLI tool for multi
 10. Do not consider release work complete until the publish workflow and published artifacts are verified.
 11. When waiting for GitHub Codex review, treat explicit Codex comments as actionable feedback; if Codex only reacts with a thumbs-up and leaves no comments, treat the review as OK.
 12. After any PR is merged, switch the local checkout back to `main`, sync it to the merged `origin/main`, and delete the local temporary work branch.
-13. Track work in the repo-root TODO note and delete completed TODO items:
+13. For automated implementation/completion workflows, create normal ready PRs by default instead of draft PRs so auto-merge can be armed without manual GitHub actions.
+14. Use draft PRs only for WIP/unfinished work; do not enable auto-merge while a PR is still draft.
+15. If a workflow creates or encounters a draft PR, the completion subagent owns marking it ready with `gh pr ready` after execution, review, and verification are complete, then enabling auto-merge.
+16. Auto-merge workflows and manual dispatches must treat draft PRs as a successful waiting/skip state, not as a failed run or a force-merge path.
+17. Track work in the repo-root TODO note and delete completed TODO items:
    - `./TODO.md`
-14. For complex tasks, the main agent must not run commands or edit files directly; it only analyzes, decomposes, assigns/publishes tasks, guides subagents, and collects results.
-15. For a single issue-fix workflow, assign ownership as follows:
+18. For complex tasks, the main agent must not run commands or edit files directly; it only analyzes, decomposes, assigns/publishes tasks, guides subagents, and collects results.
+19. For a single issue-fix workflow, assign ownership as follows:
    - Step 1 (problem analysis) and step 2 (plan/task decomposition): the main agent.
    - Steps 3-5 (code/doc edit, formatting, testing/verification): one execution subagent.
    - Step 6 (review): a second subagent that reports only actionable findings or `OK`.
@@ -111,6 +115,7 @@ GitHub Actions workflows in `.github/workflows/`:
 - `pylint.yml`: Linting
 - `publish-python.yml`: Manual PyPI release
 - `publish-release.yml`: Tag-based stable release, GitHub Release assets, PyPI publish, and Docker publish
+- `auto-merge-pr.yml`: PR auto-merge orchestration; arm auto-merge only for ready PRs and skip draft/WIP PRs until they are marked ready
 - `auto-version-bump.yml`: PR version bump automation for `bug/*` and `feature/*`
 - `bump-major-version.yml`: Manual major version bump PR creation
 - `validate-main-pr-source.yml`: Required main PR gate, including branch source, rebase/no-merge, and version bump validation

--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -68,9 +68,27 @@ def test_auto_merge_pr_workflow_enables_merge_after_required_checks() -> None:
     assert "REPO: ${{ github.repository }}" in workflow
     assert 'gh pr view "$PR_NUMBER" --repo "$REPO"' in workflow
     assert (
-        'gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --merge --delete-branch --match-head-commit "$HEAD_SHA"'
+        'gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash --delete-branch --match-head-commit "$HEAD_SHA"'
         in workflow
     )
+
+
+def test_auto_merge_pr_workflow_dispatch_skips_draft_prs_before_merge() -> None:
+    workflow = (ROOT / ".github/workflows/auto-merge-pr.yml").read_text(encoding="utf-8")
+
+    draft_check = 'is_draft="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft --jq .isDraft)"'
+    waiting_message = 'echo "PR #$PR_NUMBER is draft/WIP; waiting for gh pr ready before enabling auto-merge."'
+    merge_command = (
+        'gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash --delete-branch --match-head-commit "$HEAD_SHA"'
+    )
+
+    assert draft_check in workflow
+    assert waiting_message in workflow
+    assert "id: enable" in workflow
+    assert 'echo "skipped_draft=true" >> "$GITHUB_OUTPUT"' in workflow
+    assert "if: steps.enable.outputs.skipped_draft != 'true'" in workflow
+    assert f"{waiting_message}\n            exit 0" in workflow
+    assert workflow.index(draft_check) < workflow.index(merge_command)
 
 
 def test_auto_merge_pr_workflow_dispatches_release_watcher_for_github_token_merges() -> None:


### PR DESCRIPTION
## Summary
- Skip auto-merge enablement when the target PR is still draft/WIP
- Document ready-vs-draft PR handling for automation/completion workflows
- Add workflow automation coverage for the draft skip path

## Verification
- make format
- pytest tests/whitebox/test_workflow_automation.py
- make test