### PR TITLE
ci: publish standalone binary artifacts

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -47,6 +47,8 @@ jobs:
       with:
         name: build-artifacts
         path: |
+          out/release/projman*
+          out/projman_binary_path.txt
           out/binary/projman*
           install.sh
           install-or-upgrade.sh

--- a/docs/en/development/scripts.md
+++ b/docs/en/development/scripts.md
@@ -14,7 +14,7 @@ Installs the standalone `projman` binary produced by `build.sh`.
 ```
 
 **Features**:
-- Copies `out/binary/projman` into an install prefix
+- Prefers `out/release/projman` when copying into an install prefix; falls back to `out/binary/projman`
 - Auto-selects `/usr/local/bin` when run as root, otherwise `~/.local/bin`
 - Uses `sudo` automatically when installing to a protected prefix
 - Prints PATH guidance for user installs
@@ -63,9 +63,18 @@ Builds the Python package and the standalone `projman` binary (PyInstaller).
 **Features**:
 - Automatically runs inside `venv/` (creates it if missing)
 - Builds Python packages into `out/package/`
-- Builds the standalone binary into `out/binary/`
+- Builds the raw PyInstaller standalone binary into `out/binary/`
+- Writes the final publishable/server-uploadable binary to `out/release/projman`
+- Records the final binary path in `out/projman_binary_path.txt`, which CI uploads with the build artifact
 - Linux-only: best-effort static linking via `staticx`
 - Builds only for the current OS/arch; use GitHub Actions release workflow for multi-platform binaries
+
+**Local verification**:
+```bash
+./build.sh
+out/release/projman --version
+out/release/projman --help
+```
 
 ### `release.sh`
 

--- a/docs/zh/development/scripts.md
+++ b/docs/zh/development/scripts.md
@@ -14,7 +14,7 @@
 ```
 
 **功能**:
-- 将 `out/binary/projman` 复制到安装目录
+- 优先将 `out/release/projman` 复制到安装目录；不存在时回退到 `out/binary/projman`
 - 以 root 运行时默认安装到 `/usr/local/bin`，否则安装到 `~/.local/bin`
 - 当安装目录需要权限时自动使用 `sudo`
 - 对用户态安装输出 PATH 配置提示
@@ -63,9 +63,18 @@
 **功能**:
 - 默认在 `venv/` 中执行（不存在则自动创建）
 - Python 包输出到 `out/package/`
-- 独立二进制输出到 `out/binary/`
+- PyInstaller 原始独立二进制输出到 `out/binary/`
+- 最终可发布、可上传服务器的二进制输出到 `out/release/projman`
+- `out/projman_binary_path.txt` 记录当前系统/架构最终二进制路径，CI artifact 会随同上传
 - 仅 Linux：尝试使用 `staticx` 做静态链接（best-effort）
 - 只会构建当前系统/架构的二进制；跨平台产物请用 GitHub Actions Release 工作流
+
+**本地验证**:
+```bash
+./build.sh
+out/release/projman --version
+out/release/projman --help
+```
 
 ### `release.sh`
 

--- a/install.sh
+++ b/install.sh
@@ -83,9 +83,12 @@ if [ "$PLATFORM" = "windows" ]; then
     EXE_SUFFIX=".exe"
 fi
 
-SRC_BIN="out/binary/projman${EXE_SUFFIX}"
+SRC_BIN="out/release/projman${EXE_SUFFIX}"
 if [ ! -f "$SRC_BIN" ]; then
-    echo "$SRC_BIN binary not found. Please run ./build.sh first." >&2
+    SRC_BIN="out/binary/projman${EXE_SUFFIX}"
+fi
+if [ ! -f "$SRC_BIN" ]; then
+    echo "projman binary not found under out/release/ or out/binary/. Please run ./build.sh first." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- CI artifact includes the release standalone binary and binary path marker.
- Install script prefers the release binary and falls back to the legacy binary path.
- Development docs mention local validation commands for the standalone binary.

## Tests
- env PATH=/tmp/projectmanager-standalone-build-venv311/bin:$PATH make format
- /tmp/projectmanager-standalone-build-venv311/bin/python -m pytest tests/whitebox/test_workflow_automation.py
- /tmp/projectmanager-standalone-build-venv311/bin/python -m pytest tests/whitebox/test_bump_version_script.py
- /tmp/projectmanager-standalone-build-venv311/bin/python -m pytest tests/blackbox/test_artifact_saving.py
- git diff --check -- .github/workflows/python-app.yml install.sh docs/zh/development/scripts.md docs/en/development/scripts.md