### PR TITLE
build: ensure patchelf for staticx packaging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,6 +49,26 @@ ensure_venv() {
     fi
 }
 
+ensure_patchelf_for_staticx() {
+    if command -v patchelf >/dev/null 2>&1; then
+        return 0
+    fi
+
+    echo "patchelf not found. Installing Python patchelf package in the build environment..."
+    python -m pip install patchelf >/dev/null 2>&1 || true
+    hash -r 2>/dev/null || true
+
+    if command -v patchelf >/dev/null 2>&1; then
+        return 0
+    fi
+
+    echo "patchelf is required for Linux staticx linking but was not found." >&2
+    echo "Install patchelf before running ./build.sh, for example: apt-get install patchelf, yum install patchelf, or apk add patchelf." >&2
+    echo "If you cannot install system packages, use a build environment where patchelf is already available." >&2
+    echo "Skipping staticx; continuing with the PyInstaller binary." >&2
+    return 1
+}
+
 PLATFORM="$(detect_platform)"
 ADD_DATA_SEP=":"
 EXE_SUFFIX=""
@@ -153,30 +173,32 @@ echo "Binary generated at $BINARY_PATH"
 if [ "$PLATFORM" = "linux" ]; then
     echo -e "\033[32m--- Applying static linking for better compatibility ---\033[0m"
 
-    if ! command -v staticx >/dev/null 2>&1; then
-        echo "staticx not found. Installing for better compatibility..."
-        if ! python -m pip install staticx; then
-            echo "staticx install failed; continuing without static linking."
-        fi
-    fi
-
-    if command -v staticx >/dev/null 2>&1; then
-        # staticx depends on pkg_resources, which was removed in newer setuptools.
-        if ! python -c "import pkg_resources" >/dev/null 2>&1; then
-            echo "pkg_resources not available; installing setuptools<82 for staticx compatibility..."
-            python -m pip install "setuptools<82" >/dev/null 2>&1 || true
+    if ensure_patchelf_for_staticx; then
+        if ! command -v staticx >/dev/null 2>&1; then
+            echo "staticx not found. Installing for better compatibility..."
+            if ! python -m pip install staticx; then
+                echo "staticx install failed; continuing without static linking."
+            fi
         fi
 
-        if ! python -c "import pkg_resources" >/dev/null 2>&1; then
-            echo "pkg_resources still unavailable; skipping staticx."
-        elif staticx "$BINARY_PATH" "$BINARY_DIR/projman-static"; then
-            mv "$BINARY_DIR/projman-static" "$BINARY_PATH"
-            echo "Static linking applied successfully"
+        if command -v staticx >/dev/null 2>&1; then
+            # staticx depends on pkg_resources, which was removed in newer setuptools.
+            if ! python -c "import pkg_resources" >/dev/null 2>&1; then
+                echo "pkg_resources not available; installing setuptools<82 for staticx compatibility..."
+                python -m pip install "setuptools<82" >/dev/null 2>&1 || true
+            fi
+
+            if ! python -c "import pkg_resources" >/dev/null 2>&1; then
+                echo "pkg_resources still unavailable; skipping staticx."
+            elif staticx "$BINARY_PATH" "$BINARY_DIR/projman-static"; then
+                mv "$BINARY_DIR/projman-static" "$BINARY_PATH"
+                echo "Static linking applied successfully"
+            else
+                echo "staticx failed; continuing without static linking."
+            fi
         else
-            echo "staticx failed; continuing without static linking."
+            echo "staticx unavailable; continuing without static linking."
         fi
-    else
-        echo "staticx unavailable; continuing without static linking."
     fi
 else
     echo "Skipping staticx (unsupported on $PLATFORM)."

--- a/docs/en/development/scripts.md
+++ b/docs/en/development/scripts.md
@@ -66,7 +66,7 @@ Builds the Python package and the standalone `projman` binary (PyInstaller).
 - Builds the raw PyInstaller standalone binary into `out/binary/`
 - Writes the final publishable/server-uploadable binary to `out/release/projman`
 - Records the final binary path in `out/projman_binary_path.txt`, which CI uploads with the build artifact
-- Linux-only: best-effort static linking via `staticx`
+- Linux-only: best-effort static linking via `staticx`; this step requires `patchelf`, so the script first tries to install the Python `patchelf` package in the build environment and skips static linking with a clear hint if `patchelf` is still unavailable
 - Builds only for the current OS/arch; use GitHub Actions release workflow for multi-platform binaries
 
 **Local verification**:

--- a/docs/zh/development/scripts.md
+++ b/docs/zh/development/scripts.md
@@ -66,7 +66,7 @@
 - PyInstaller 原始独立二进制输出到 `out/binary/`
 - 最终可发布、可上传服务器的二进制输出到 `out/release/projman`
 - `out/projman_binary_path.txt` 记录当前系统/架构最终二进制路径，CI artifact 会随同上传
-- 仅 Linux：尝试使用 `staticx` 做静态链接（best-effort）
+- 仅 Linux：尝试使用 `staticx` 做静态链接（best-effort）；该阶段需要 `patchelf`，脚本会先尝试在构建环境中安装 Python `patchelf` 包，仍不可用时会提示预装系统依赖并跳过静态链接
 - 只会构建当前系统/架构的二进制；跨平台产物请用 GitHub Actions Release 工作流
 
 **本地验证**:

--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -232,3 +232,30 @@ def test_publish_release_test_job_installs_console_script_before_pytest() -> Non
     assert "source venv/bin/activate" in workflow
     assert "python -m pip install --no-deps --no-build-isolation -e ." in workflow
     assert "command -v projman" in workflow
+
+
+def test_linux_build_jobs_install_patchelf_before_build_script() -> None:
+    workflow_names = (
+        "python-app.yml",
+        "publish-release.yml",
+        "publish-beta-release.yml",
+    )
+
+    for workflow_name in workflow_names:
+        workflow = (ROOT / f".github/workflows/{workflow_name}").read_text(encoding="utf-8")
+        for build_match in re.finditer(r"run: bash build\.sh", workflow):
+            dependency_index = workflow.rfind("sudo apt-get install -y", 0, build_match.start())
+            assert dependency_index != -1, workflow_name
+            dependency_step = workflow[dependency_index : build_match.start()]
+            assert "patchelf" in dependency_step, workflow_name
+
+
+def test_build_script_checks_patchelf_before_linux_staticx() -> None:
+    build_script = (ROOT / "build.sh").read_text(encoding="utf-8")
+
+    patchelf_index = build_script.index("command -v patchelf")
+    staticx_index = build_script.index("command -v staticx")
+
+    assert patchelf_index < staticx_index
+    assert "python -m pip install patchelf" in build_script
+    assert "Install patchelf before running ./build.sh" in build_script


### PR DESCRIPTION
## Summary
- check for patchelf before Linux staticx packaging and try the Python patchelf package in the build environment
- keep staticx best-effort with a clear fallback message when patchelf is unavailable
- document the Linux staticx dependency behavior and cover it with workflow/build-script tests

## Verification
- PATH=/tmp/projectmanager-standalone-build-venv311/bin:/Users/wangguanran/.codex/tmp/arg0/codex-arg0st9ilb:/Users/wangguanran/.bun/bin:/Users/wangguanran/go/bin:/Users/wangguanran/.local/bin:/Users/wangguanran/bin:/Users/wangguanran/.opencode/bin:/Users/wangguanran/.opencode/bin:/Users/wangguanran/.nvm/versions/node/v24.12.0/bin:/Users/wangguanran/.bun/bin:/Users/wangguanran/bin:/opt/homebrew/opt/openjdk@17/bin:/opt/homebrew/share/android-commandlinetools/emulator:/opt/homebrew/share/android-commandlinetools/platform-tools:/opt/homebrew/share/android-commandlinetools/cmdline-tools/latest/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/wangguanran/.cargo/bin:/Users/wangguanran/Library/Python/3.9/bin:/Users/wangguanran/Library/Python/3.9/bin:/Applications/Codex.app/Contents/Resources make format
- bash -n build.sh install.sh
- python -m pytest tests/whitebox/test_workflow_automation.py
- python -m pytest tests/whitebox/test_bump_version_script.py
- git diff --check