### PR TITLE
build: prefer compatible patchelf for staticx

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,22 +49,105 @@ ensure_venv() {
     fi
 }
 
+use_existing_patchelf_for_staticx() {
+    local patchelf_path patchelf_version
+    patchelf_path="$1"
+    if [ -z "$patchelf_path" ]; then
+        return 1
+    fi
+
+    patchelf_version="$("$patchelf_path" --version 2>/dev/null || true)"
+    if [ -z "$patchelf_version" ]; then
+        return 1
+    fi
+
+    case "$patchelf_version" in
+        *" 0.17.2"*|*"patchelf 0.17.2"*)
+            echo "Existing patchelf 0.17.2 is not compatible with this staticx build; skipping staticx." >&2
+            return 1
+            ;;
+    esac
+
+    echo "Using existing patchelf: $patchelf_path"
+    return 0
+}
+
 ensure_patchelf_for_staticx() {
-    if command -v patchelf >/dev/null 2>&1; then
+    local arch deb_url fallback_dir deb_path fallback_bin existing_patchelf_path
+    existing_patchelf_path="$(command -v patchelf 2>/dev/null || true)"
+    arch="$(uname -m 2>/dev/null || echo unknown)"
+    if [ "$arch" != "x86_64" ] && [ "$arch" != "amd64" ]; then
+        if use_existing_patchelf_for_staticx "$existing_patchelf_path"; then
+            return 0
+        fi
+        echo "patchelf is required for Linux staticx linking but was not found." >&2
+        echo "Automatic fallback is only available on Linux x86_64/amd64; detected '$arch'." >&2
+        echo "Skipping staticx; continuing with the PyInstaller binary." >&2
+        return 1
+    fi
+
+    if ! command -v dpkg-deb >/dev/null 2>&1; then
+        echo "patchelf is required for Linux staticx linking but was not found." >&2
+        echo "dpkg-deb is unavailable, so the build script cannot unpack the distribution patchelf fallback." >&2
+        if use_existing_patchelf_for_staticx "$existing_patchelf_path"; then
+            return 0
+        fi
+        echo "Skipping staticx; continuing with the PyInstaller binary." >&2
+        return 1
+    fi
+
+    if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
+        echo "patchelf is required for Linux staticx linking but was not found." >&2
+        echo "Neither curl nor wget is available to download the distribution patchelf fallback." >&2
+        if use_existing_patchelf_for_staticx "$existing_patchelf_path"; then
+            return 0
+        fi
+        echo "Skipping staticx; continuing with the PyInstaller binary." >&2
+        return 1
+    fi
+
+    deb_url="https://archive.ubuntu.com/ubuntu/pool/universe/p/patchelf/patchelf_0.14.3-1_amd64.deb"
+    fallback_dir="${OUT_DIR:-out}/staticx-tools/patchelf-jammy"
+    deb_path="$fallback_dir/patchelf_0.14.3-1_amd64.deb"
+    fallback_bin="$fallback_dir/usr/bin/patchelf"
+
+    echo "Preparing Ubuntu Jammy patchelf fallback for staticx..."
+    mkdir -p "$fallback_dir"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$deb_url" -o "$deb_path" || true
+    else
+        wget -q "$deb_url" -O "$deb_path" || true
+    fi
+
+    if [ ! -s "$deb_path" ]; then
+        echo "Failed to download distribution patchelf fallback from $deb_url." >&2
+        if use_existing_patchelf_for_staticx "$existing_patchelf_path"; then
+            return 0
+        fi
+        echo "Skipping staticx; continuing with the PyInstaller binary." >&2
+        return 1
+    fi
+
+    if ! dpkg-deb -x "$deb_path" "$fallback_dir"; then
+        echo "Failed to unpack distribution patchelf fallback." >&2
+        if use_existing_patchelf_for_staticx "$existing_patchelf_path"; then
+            return 0
+        fi
+        echo "Skipping staticx; continuing with the PyInstaller binary." >&2
+        return 1
+    fi
+
+    if [ -x "$fallback_bin" ] && "$fallback_bin" --version >/dev/null 2>&1; then
+        export PATH="$fallback_dir/usr/bin:$PATH"
+        hash -r 2>/dev/null || true
+        "$fallback_bin" --version
         return 0
     fi
 
-    echo "patchelf not found. Installing Python patchelf package in the build environment..."
-    python -m pip install patchelf >/dev/null 2>&1 || true
-    hash -r 2>/dev/null || true
-
-    if command -v patchelf >/dev/null 2>&1; then
+    echo "Distribution patchelf fallback is not runnable after unpacking." >&2
+    if use_existing_patchelf_for_staticx "$existing_patchelf_path"; then
         return 0
     fi
-
-    echo "patchelf is required for Linux staticx linking but was not found." >&2
-    echo "Install patchelf before running ./build.sh, for example: apt-get install patchelf, yum install patchelf, or apk add patchelf." >&2
-    echo "If you cannot install system packages, use a build environment where patchelf is already available." >&2
     echo "Skipping staticx; continuing with the PyInstaller binary." >&2
     return 1
 }

--- a/docs/en/development/scripts.md
+++ b/docs/en/development/scripts.md
@@ -66,7 +66,7 @@ Builds the Python package and the standalone `projman` binary (PyInstaller).
 - Builds the raw PyInstaller standalone binary into `out/binary/`
 - Writes the final publishable/server-uploadable binary to `out/release/projman`
 - Records the final binary path in `out/projman_binary_path.txt`, which CI uploads with the build artifact
-- Linux-only: best-effort static linking via `staticx`; this step requires `patchelf`, so the script first tries to install the Python `patchelf` package in the build environment and skips static linking with a clear hint if `patchelf` is still unavailable
+- Linux-only: best-effort static linking via `staticx`; on Linux x86_64/amd64 this step first downloads and unpacks the Ubuntu Jammy `patchelf` deb into the build output and prepends it to `PATH`; only if that fallback cannot be prepared or run does the script try an existing compatible `patchelf` (known-incompatible 0.17.2 is rejected); if no usable `patchelf` is available, the script skips `staticx` and keeps the PyInstaller binary
 - Builds only for the current OS/arch; use GitHub Actions release workflow for multi-platform binaries
 
 **Local verification**:

--- a/docs/zh/development/scripts.md
+++ b/docs/zh/development/scripts.md
@@ -66,7 +66,7 @@
 - PyInstaller 原始独立二进制输出到 `out/binary/`
 - 最终可发布、可上传服务器的二进制输出到 `out/release/projman`
 - `out/projman_binary_path.txt` 记录当前系统/架构最终二进制路径，CI artifact 会随同上传
-- 仅 Linux：尝试使用 `staticx` 做静态链接（best-effort）；该阶段需要 `patchelf`，脚本会先尝试在构建环境中安装 Python `patchelf` 包，仍不可用时会提示预装系统依赖并跳过静态链接
+- 仅 Linux：尝试使用 `staticx` 做静态链接（best-effort）；在 Linux x86_64/amd64 上，该阶段会先下载并解包 Ubuntu Jammy `patchelf` deb 到构建输出目录并前置到 `PATH`；只有该 fallback 无法准备或运行时，才尝试使用已有且兼容的 `patchelf`（会拒绝已知不兼容的 0.17.2）；如果仍无可用 `patchelf`，则跳过 `staticx`，保留 PyInstaller 二进制
 - 只会构建当前系统/架构的二进制；跨平台产物请用 GitHub Actions Release 工作流
 
 **本地验证**:

--- a/tests/whitebox/test_workflow_automation.py
+++ b/tests/whitebox/test_workflow_automation.py
@@ -247,15 +247,29 @@ def test_linux_build_jobs_install_patchelf_before_build_script() -> None:
             dependency_index = workflow.rfind("sudo apt-get install -y", 0, build_match.start())
             assert dependency_index != -1, workflow_name
             dependency_step = workflow[dependency_index : build_match.start()]
-            assert "patchelf" in dependency_step, workflow_name
+            assert re.search(r"sudo apt-get install -y[^\n]*\bpatchelf\b", dependency_step), workflow_name
 
 
 def test_build_script_checks_patchelf_before_linux_staticx() -> None:
     build_script = (ROOT / "build.sh").read_text(encoding="utf-8")
 
-    patchelf_index = build_script.index("command -v patchelf")
+    helper_index = build_script.index("use_existing_patchelf_for_staticx")
+    deb_index = build_script.index("patchelf_0.14.3-1_amd64.deb")
+    fallback_bin_index = build_script.index('fallback_bin="$fallback_dir/usr/bin/patchelf"')
+    fallback_check_index = build_script.index('if [ -x "$fallback_bin" ]')
+    fallback_path_index = build_script.index('export PATH="$fallback_dir/usr/bin:$PATH"')
     staticx_index = build_script.index("command -v staticx")
 
-    assert patchelf_index < staticx_index
-    assert "python -m pip install patchelf" in build_script
-    assert "Install patchelf before running ./build.sh" in build_script
+    assert helper_index < deb_index < fallback_bin_index < fallback_check_index < fallback_path_index < staticx_index
+    assert "archive.ubuntu.com/ubuntu/pool/universe/p/patchelf" in build_script
+    assert "dpkg-deb -x" in build_script
+    assert 'export PATH="$fallback_dir/usr/bin:$PATH"' in build_script
+    assert "patchelf 0.17.2" in build_script
+    assert "if command -v patchelf >/dev/null 2>&1; then\n        return 0\n    fi" not in build_script
+    assert 'if use_existing_patchelf_for_staticx "$existing_patchelf_path"; then' in build_script
+    assert "python -m pip install patchelf" not in build_script
+    assert (
+        "sudo apt-get install"
+        not in build_script[build_script.index("ensure_patchelf_for_staticx") : build_script.index("PLATFORM=")]
+    )
+    assert "Skipping staticx; continuing with the PyInstaller binary." in build_script


### PR DESCRIPTION
## Summary
- keep CI system patchelf installation before Linux builds
- add a Linux x86_64 staticx fallback that uses Ubuntu Jammy patchelf 0.14.3
- reject known-incompatible patchelf 0.17.2 and document the build behavior

## Verification
- PATH=/tmp/projectmanager-standalone-build-venv311/bin:/Users/wangguanran/.codex/tmp/arg0/codex-arg0st9ilb:/Users/wangguanran/.bun/bin:/Users/wangguanran/go/bin:/Users/wangguanran/.local/bin:/Users/wangguanran/bin:/Users/wangguanran/.opencode/bin:/Users/wangguanran/.opencode/bin:/Users/wangguanran/.nvm/versions/node/v24.12.0/bin:/Users/wangguanran/.bun/bin:/Users/wangguanran/bin:/opt/homebrew/opt/openjdk@17/bin:/opt/homebrew/share/android-commandlinetools/emulator:/opt/homebrew/share/android-commandlinetools/platform-tools:/opt/homebrew/share/android-commandlinetools/cmdline-tools/latest/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/wangguanran/.cargo/bin:/Users/wangguanran/Library/Python/3.9/bin:/Users/wangguanran/Library/Python/3.9/bin:/Applications/Codex.app/Contents/Resources make format
- bash -n build.sh install.sh
- /tmp/projectmanager-standalone-build-venv311/bin/python -m pytest tests/whitebox/test_workflow_automation.py
- /tmp/projectmanager-standalone-build-venv311/bin/python -m pytest tests/whitebox/test_bump_version_script.py
- git diff --check